### PR TITLE
Add SFC to Chocola

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,37 +7,24 @@ Chocola is a JavaScript library for creating web user interfaces.
 ## Usage
 
 ```html
-<!-- counter.html -->
-<div>
-  <button title={title}>{text}</button>
+<!-- MyTitle.html -->
+<script>
+    let self = new HTMLElement;
 
-  <div class="main">
-    <div class="number">{count}</div>
-  </div>
-</div>
-```
+    export let title = "Default title";
 
-```js
-import body from "./html/counter.html";
-import styles from "./css/counter.css";
+    function $runtime() {
+        console.log("Component mounted:", self)
+    }
+</script>
 
-function RUNTIME(self, ctx) {
-  const btn = self.querySelector("button");
-  const number = self.querySelector(".number");
+<template>
+    <h1>{title}</h1>
+</template>
 
-  btn.addEventListener("click", () => {
-    ctx.count++;
-    number.textContent = ctx.count;
-  })
-}
-
-export default function Counter() {
-  return {
-    body,
-    styles,
-    script: RUNTIME
-  }
-}
+<style>
+    button { color: chocolate; }
+</style>
 ```
 
 ## Documentation

--- a/compiler/component-processor.js
+++ b/compiler/component-processor.js
@@ -111,6 +111,17 @@ function removeDelIfAttr(el) {
   el.removeAttribute("del:if");
 }
 
+function extractPropsDefaults(script) {
+  if (!script) return [];
+  const propsRegex = /export\s+let\s+([a-zA-Z_$][0-9a-zA-Z_$]*)\s*(?:=\s*([^;]+))?;/g;
+  let props = [];
+  let match;
+  while ((match = propsRegex.exec(script)) !== null) {
+    props.push({ name: match[1].trim(), defaultValue: match[2]?.trim() });
+  }
+  return props;
+}
+
 function interpolateNode(root, ctxProxy) {
   const stack = [root];
   while (stack.length) {
@@ -200,20 +211,6 @@ export function processComponentElement(
   if (!instance || instance === undefined) return false;
   if (renderChain && renderChain.includes(compName)) return false;
 
-  let ctx;
-  if (staticCtxRegistry && staticCtxRegistry.has(element)) {
-    ctx = staticCtxRegistry.get(element);
-  } else {
-    ctx = extractContextFromElement(element);
-    staticCtxRegistry && staticCtxRegistry.set(element, ctx);
-  }
-  const elInnerHtml = element.innerHTML;
-
-  const ctxProxy = new Proxy(ctx, {
-    has() { return true; },
-    get(target, key) { return target[key]; }
-  });
-
   instance = protectCurlyBraces(instance);
   const dom = new JSDOM(instance);
   const doc = dom.window.document;
@@ -225,6 +222,37 @@ export function processComponentElement(
     console.warn(chalk.yellow(`${compName} — component is missing a <template>`));
     return false;
   }
+
+  // Extract props with defaults from component script
+  const compProps = extractPropsDefaults(script);
+
+  let ctx;
+  if (staticCtxRegistry && staticCtxRegistry.has(element)) {
+    ctx = staticCtxRegistry.get(element);
+  } else {
+    ctx = extractContextFromElement(element);
+    staticCtxRegistry && staticCtxRegistry.set(element, ctx);
+  }
+
+  // Apply default values for props not provided on the element
+  if (compProps.length > 0) {
+    compProps.forEach(({ name, defaultValue }) => {
+      if (defaultValue !== undefined && !(name in ctx)) {
+        try {
+          ctx[name] = compileExpression(defaultValue, false)();
+        } catch {
+          ctx[name] = defaultValue;
+        }
+      }
+    });
+  }
+
+  const elInnerHtml = element.innerHTML;
+
+  const ctxProxy = new Proxy(ctx, {
+    has() { return true; },
+    get(target, key) { return target[key]; }
+  });
 
   const fragment = JSDOM.fragment(template);
 
@@ -399,9 +427,14 @@ export function processComponentElement(
       for (const [key, value] of Object.entries(runtimeCtx)) {
         ctxDef += `ctx.${key} = ctx.${key}||${JSON.stringify(value)};\n`;
       }
+      // Add defaults from export let declarations
+      for (const { name, defaultValue } of compProps) {
+        if (defaultValue !== undefined) {
+          ctxDef += `ctx.${name} = ctx.${name}||${defaultValue};\n`;
+        }
+      }
 
       script = script.replace(ctxRegex, "ctx");
-      script = script.replace(/\$runtime\([^)]*\)\s*{/, match => match + "\n" + ctxDef);
 
       function extractRuntime(script) {
         const startRegex = /(?:async\s+)?function\s+\$runtime\(([^)]*)\)\s*\{/;
@@ -435,31 +468,18 @@ export function processComponentElement(
         return fullMatch;
       }
 
-      function extractProps(script) {
-        const propsRegex = /export\s+let\s+([a-zA-Z_$][0-9a-zA-Z_$]*)\s*(?:=\s*([^;]+))?;/g;
-
-        let props = [];
-        let match;
-
-        while ((match = propsRegex.exec(script)) !== null) {
-          props.push(match[1].trim());
-        }
-
-        return props;
-      }
-
       let runtime = extractRuntime(script);
-      let props = extractProps(script);
 
       if (runtime) {
-        if (props.length > 0) {
-          props.forEach(prop => {
-            console.log(`${compName} replacing prop: ${prop}`)
-            runtime = runtime.replace(prop, `ctx.${prop}`);
-          });
-
-          console.log(runtime)
+        for (const { name } of compProps) {
+          console.log(`${compName} replacing prop: ${name}`)
+          runtime = runtime.replace(name, `ctx.${name}`);
         }
+
+        // Inject ctxDef after props replacement so ctxDef lines aren't double-replaced
+        runtime = runtime.replace(/\$runtime\([^)]*\)\s*\{/, match => match + "\n" + ctxDef);
+
+        console.log(runtime)
 
         let letterEntry = runtimeMap && runtimeMap.get(compName);
         let letter;

--- a/compiler/component-processor.js
+++ b/compiler/component-processor.js
@@ -142,6 +142,21 @@ function interpolateNode(root, ctxProxy) {
   }
 }
 
+function getLineNumber(sourceContent, parentContent, idxInParent) {
+  if (sourceContent === parentContent) {
+    return parentContent.substring(0, idxInParent).split("\n").length;
+  }
+  const templateStartMatch = sourceContent.match(/<template[^>]*>/);
+  if (templateStartMatch) {
+    const contentStart = templateStartMatch.index + templateStartMatch[0].length;
+    const beforeContent = sourceContent.substring(0, contentStart);
+    const linesInBefore = beforeContent.split("\n").length;
+    const linesInTemplate = parentContent.substring(0, idxInParent).split("\n").length;
+    return linesInBefore + linesInTemplate - 1;
+  }
+  return null;
+}
+
 function validateChainStructure(parent, sourceFile, sourceContent, parentContent) {
   const children = [...parent.children];
   let chainActive = false;
@@ -157,10 +172,11 @@ function validateChainStructure(parent, sourceFile, sourceContent, parentContent
         const tag = child.tagName.toLowerCase();
         const attr = hasElif ? "elif" : "else";
         let loc = sourceFile;
-        if (sourceContent && sourceContent === parentContent) {
+        if (sourceContent && parentContent) {
           const idx = parentContent.indexOf(child.outerHTML);
           if (idx !== -1) {
-            loc = `${sourceFile}:${parentContent.substring(0, idx).split("\n").length}`;
+            const lineNum = getLineNumber(sourceContent, parentContent, idx);
+            if (lineNum !== null) loc = `${sourceFile}:${lineNum}`;
           }
         }
         throwError(`${loc}\n    <${tag}> has ${attr} without a preceding if/del-if sibling`);
@@ -260,7 +276,7 @@ export function processComponentElement(
   if (sourceFile) {
     validateChainStructure(slotFragment, sourceFile, sourceContent, elInnerHtml);
   }
-  validateChainStructure(fragment, instance.__sourceFile || compName, template, template);
+  validateChainStructure(fragment, instance.__sourceFile || compName, instance, template);
   Array.from(fragment.querySelectorAll("slot")).forEach(slot => {
     slot.replaceWith(slotFragment);
   });

--- a/compiler/component-processor.js
+++ b/compiler/component-processor.js
@@ -194,8 +194,8 @@ export function processComponentElement(
   sourceContent
 ) {
   const tagName = element.tagName.toLowerCase();
-  const compName = tagName + ".js";
-  const instance = loadedComponents.get(compName);
+  const compName = tagName + ".html";
+  let instance = loadedComponents.get(compName);
 
   if (!instance || instance === undefined) return false;
   if (renderChain && renderChain.includes(compName)) return false;
@@ -207,233 +207,236 @@ export function processComponentElement(
     ctx = extractContextFromElement(element);
     staticCtxRegistry && staticCtxRegistry.set(element, ctx);
   }
-  const srcInnerHtml = element.innerHTML;
+  const elInnerHtml = element.innerHTML;
 
   const ctxProxy = new Proxy(ctx, {
     has() { return true; },
     get(target, key) { return target[key]; }
   });
 
-  if (instance.body) {
-    let body = protectCurlyBraces(instance.body);
+  instance = protectCurlyBraces(instance);
+  const dom = new JSDOM(instance);
+  const doc = dom.window.document;
+  let script = doc.querySelector("script")?.innerHTML;
+  let template = doc.querySelector("template")?.innerHTML;
+  let styles = doc.querySelector("style")?.innerHTML;
 
-    const fragment = JSDOM.fragment(body);
+  if (!template) {
+    console.warn(chalk.yellow(`${compName} — component is missing a <template>`));
+    return false;
+  }
+  
+  const fragment = JSDOM.fragment(template);
 
-    const slotFragment = JSDOM.fragment(srcInnerHtml);
-    if (sourceFile) {
-      validateChainStructure(slotFragment, sourceFile, sourceContent, srcInnerHtml);
+  const slotFragment = JSDOM.fragment(elInnerHtml);
+  if (sourceFile) {
+    validateChainStructure(slotFragment, sourceFile, sourceContent, elInnerHtml);
+  }
+  validateChainStructure(fragment, instance.__sourceFile || compName, template, template);
+  Array.from(fragment.querySelectorAll("slot")).forEach(slot => {
+    slot.replaceWith(slotFragment);
+  });
+
+  const childEntries = Array.from(fragment.querySelectorAll("*")).map(el => ({
+    el,
+    parent: el.parentNode
+  }));
+  const condChains = new Map();
+
+  childEntries.forEach(({ el: child, parent }) => {
+    if (!condChains.has(parent)) {
+      condChains.set(parent, { active: false, rendered: false });
     }
-    validateChainStructure(fragment, instance.__sourceFile || compName, body, body);
-    Array.from(fragment.querySelectorAll("slot")).forEach(slot => {
-      slot.replaceWith(slotFragment);
-    });
+    const condChain = condChains.get(parent);
 
-    const childEntries = Array.from(fragment.querySelectorAll("*")).map(el => ({
-      el,
-      parent: el.parentNode
-    }));
-    const condChains = new Map();
+    const hasIf = child.hasAttribute("if");
+    const hasDelIf = hasDelIfAttr(child);
+    const hasElif = child.hasAttribute("elif");
+    const hasElse = child.hasAttribute("else");
 
-    childEntries.forEach(({ el: child, parent }) => {
-      if (!condChains.has(parent)) {
-        condChains.set(parent, { active: false, rendered: false });
+    if (hasElif || hasElse) {
+      if (!condChain.active) {
+        throwError(`${instance.__sourceFile || compName}: <${child.tagName.toLowerCase()}> has ${hasElif ? "elif" : "else"} without a preceding if/del-if sibling`);
       }
-      const condChain = condChains.get(parent);
-
-      const hasIf = child.hasAttribute("if");
-      const hasDelIf = hasDelIfAttr(child);
-      const hasElif = child.hasAttribute("elif");
-      const hasElse = child.hasAttribute("else");
-
-      if (hasElif || hasElse) {
-        if (!condChain.active) {
-          throwError(`${instance.__sourceFile || compName}: <${child.tagName.toLowerCase()}> has ${hasElif ? "elif" : "else"} without a preceding if/del-if sibling`);
-        }
-        if (condChain.rendered) {
-          child.remove();
-          if (hasElse) {
-            condChain.active = false;
-          }
-          return;
-        }
-      }
-
-      if (child.tagName.toLowerCase() === "void") {
-        if (hasElif || hasElse) {
-          if (hasElif) {
-            const expr = child.getAttribute("elif").slice(1, -1);
-            const fn = compileExpression(expr, true);
-            if (!fn(ctxProxy)) {
-              child.remove();
-              return;
-            }
-          }
-          child.replaceWith(...child.children);
-          condChain.rendered = true;
-          if (hasElse) {
-            condChain.active = false;
-          }
-        } else if (hasIf || hasDelIf) {
-          const raw = hasIf ? child.getAttribute("if") : getDelIfAttr(child);
-          const expr = raw.slice(1, -1);
-          const fn = compileExpression(expr, true);
-          condChain.active = true;
-          if (fn(ctxProxy)) {
-            child.replaceWith(...child.children);
-            condChain.rendered = true;
-          } else {
-            child.remove();
-            condChain.rendered = false;
-          }
-        } else {
-          child.replaceWith(...child.children);
+      if (condChain.rendered) {
+        child.remove();
+        if (hasElse) {
           condChain.active = false;
-          condChain.rendered = false;
         }
         return;
       }
+    }
 
-      const reservedAttrs = ["if", "del:if", "elif", "else"];
-
-      Array.from(child.attributes).forEach(attribute => {
-        if (!attribute || attribute === undefined) return;
-        if (reservedAttrs.includes(attribute.name)) return;
-        attribute.value = attribute.value.replace(
-          /\{([^}]+)\}/g,
-          (_, expr) => {
-            try {
-              return compileExpression(expr, true)(ctxProxy);
-            } catch {
-              return "";
-            }
+    if (child.tagName.toLowerCase() === "void") {
+      if (hasElif || hasElse) {
+        if (hasElif) {
+          const expr = child.getAttribute("elif").slice(1, -1);
+          const fn = compileExpression(expr, true);
+          if (!fn(ctxProxy)) {
+            child.remove();
+            return;
           }
-        );
-      });
-
-      processComponentElement(
-        child,
-        loadedComponents,
-        runtimeChunks,
-        compIdColl,
-        letterState,
-        runtimeMap,
-        cssScopes,
-        cssScopesMap,
-        scopedStyles,
-        renderChain.concat(compName),
-        staticCtxRegistry,
-        instance.__sourceFile || compName,
-        body
-      );
-
-      if (hasIf) {
-        const expr = child.getAttribute("if").slice(1, -1);
-        const fn = compileExpression(expr, true);
-        condChain.active = true;
-        if (fn(ctxProxy)) {
-          condChain.rendered = true;
-        } else {
-          child.style.display = "none";
-          condChain.rendered = false;
         }
-        child.removeAttribute("if");
-      } else if (hasDelIf) {
-        const expr = getDelIfAttr(child).slice(1, -1);
-        const fn = compileExpression(expr, true);
-        condChain.active = true;
-        if (fn(ctxProxy)) {
-          condChain.rendered = true;
-        } else {
-          child.remove();
-          condChain.rendered = false;
-        }
-        removeDelIfAttr(child);
-      } else if (hasElif) {
-        const expr = child.getAttribute("elif").slice(1, -1);
-        const fn = compileExpression(expr, true);
-        if (fn(ctxProxy)) {
-          condChain.rendered = true;
-        } else {
-          child.remove();
-        }
-        child.removeAttribute("elif");
-      } else if (hasElse) {
+        child.replaceWith(...child.children);
         condChain.rendered = true;
-        condChain.active = false;
-        child.removeAttribute("else");
+        if (hasElse) {
+          condChain.active = false;
+        }
+      } else if (hasIf || hasDelIf) {
+        const raw = hasIf ? child.getAttribute("if") : getDelIfAttr(child);
+        const expr = raw.slice(1, -1);
+        const fn = compileExpression(expr, true);
+        condChain.active = true;
+        if (fn(ctxProxy)) {
+          child.replaceWith(...child.children);
+          condChain.rendered = true;
+        } else {
+          child.remove();
+          condChain.rendered = false;
+        }
       } else {
+        child.replaceWith(...child.children);
         condChain.active = false;
         condChain.rendered = false;
       }
+      return;
+    }
 
-      interpolateNode(child, ctxProxy)
-    });
+    const reservedAttrs = ["if", "del:if", "elif", "else"];
 
-    const firstChild = fragment.firstChild;
-
-    if (firstChild && firstChild.nodeType === 1) {
-      if (instance.script || instance.effects) {
-        const compId = "chid-" + genRandomId(compIdColl);
-        firstChild.setAttribute("chid", compId);
-
-        let script = instance.script && instance.script.toString();
-
-        const ctxRegex = /ctx\s*=\s*({.*?})/;
-        const ctxMatch = script.match(ctxRegex);
-        let runtimeCtx = {};
-        if (ctxMatch) {
+    Array.from(child.attributes).forEach(attribute => {
+      if (!attribute || attribute === undefined) return;
+      if (reservedAttrs.includes(attribute.name)) return;
+      attribute.value = attribute.value.replace(
+        /\{([^}]+)\}/g,
+        (_, expr) => {
           try {
-            runtimeCtx = JSON.parse(ctxMatch[1].replace(/(\w+):/g, '"$1":'));
-          } catch (e) {
-            runtimeCtx = {};
+            return compileExpression(expr, true)(ctxProxy);
+          } catch {
+            return "";
           }
         }
-        let ctxDef = "";
-        for (const [key, value] of Object.entries(runtimeCtx)) {
-          ctxDef += `ctx.${key} = ctx.${key}||${JSON.stringify(value)};\n`;
+      );
+    });
+
+    processComponentElement(
+      child,
+      loadedComponents,
+      runtimeChunks,
+      compIdColl,
+      letterState,
+      runtimeMap,
+      cssScopes,
+      cssScopesMap,
+      scopedStyles,
+      renderChain.concat(compName),
+      staticCtxRegistry,
+      compName,
+      template
+    );
+
+    if (hasIf) {
+      const expr = child.getAttribute("if").slice(1, -1);
+      const fn = compileExpression(expr, true);
+      condChain.active = true;
+      if (fn(ctxProxy)) {
+        condChain.rendered = true;
+      } else {
+        child.style.display = "none";
+        condChain.rendered = false;
+      }
+      child.removeAttribute("if");
+    } else if (hasDelIf) {
+      const expr = getDelIfAttr(child).slice(1, -1);
+      const fn = compileExpression(expr, true);
+      condChain.active = true;
+      if (fn(ctxProxy)) {
+        condChain.rendered = true;
+      } else {
+        child.remove();
+        condChain.rendered = false;
+      }
+      removeDelIfAttr(child);
+    } else if (hasElif) {
+      const expr = child.getAttribute("elif").slice(1, -1);
+      const fn = compileExpression(expr, true);
+      if (fn(ctxProxy)) {
+        condChain.rendered = true;
+      } else {
+        child.remove();
+      }
+      child.removeAttribute("elif");
+    } else if (hasElse) {
+      condChain.rendered = true;
+      condChain.active = false;
+      child.removeAttribute("else");
+    } else {
+      condChain.active = false;
+      condChain.rendered = false;
+    }
+
+    interpolateNode(child, ctxProxy)
+  });
+
+  const firstChild = fragment.children[0];
+
+  if (firstChild && firstChild.nodeType === 1) {
+    if (script) {
+      const compId = "chid-" + genRandomId(compIdColl);
+      firstChild.setAttribute("chid", compId);
+
+      const ctxRegex = /ctx\s*=\s*({.*?})/;
+      const ctxMatch = script.match(ctxRegex);
+      let runtimeCtx = {};
+      if (ctxMatch) {
+        try {
+          runtimeCtx = JSON.parse(ctxMatch[1].replace(/(\w+):/g, '"$1":'));
+        } catch (e) {
+          runtimeCtx = {};
         }
-        script = script.replace(ctxRegex, "ctx");
-        script = script.replace(/RUNTIME\([^)]*\)\s*{/, match => match + "\n" + ctxDef);
-
-        let letterEntry = runtimeMap && runtimeMap.get(compName);
-        let letter;
-        if (!letterEntry) {
-          letter = getNextLetter(letterState);
-          script = script.replace(/RUNTIME/g, `${letter}RUNTIME`);
-          runtimeChunks.push(script);
-          runtimeMap && runtimeMap.set(compName, { letter });
-        } else {
-          letter = letterEntry.letter;
-        }
-
-        runtimeChunks.push(`${letter}RUNTIME(document.querySelector('[chid="${compId}"]'), ${JSON.stringify(ctx)});`);
       }
-    }
-
-    let style = instance.styles && instance.styles.toString();
-    if (style) {
-      let cssId = cssScopesMap && cssScopesMap.get(compName);
-      if (!cssId) {
-        cssId = genRandomId(cssScopes, 8, true);
-        cssScopesMap.set(compName, cssId);
+      let ctxDef = "";
+      for (const [key, value] of Object.entries(runtimeCtx)) {
+        ctxDef += `ctx.${key} = ctx.${key}||${JSON.stringify(value)};\n`;
       }
-      if (fragment.firstChild && fragment.firstChild.nodeType === 1) {
-        fragment.firstChild.classList.add(cssId);
+      
+      script = script.replace(ctxRegex, "ctx");
+      script = script.replace(/RUNTIME\([^)]*\)\s*{/, match => match + "\n" + ctxDef);
+
+      let letterEntry = runtimeMap && runtimeMap.get(compName);
+      let letter;
+      if (!letterEntry) {
+        letter = getNextLetter(letterState);
+        script = script.replace(/RUNTIME/g, `${letter}RUNTIME`);
+        runtimeChunks.push(script);
+        runtimeMap && runtimeMap.set(compName, { letter });
+      } else {
+        letter = letterEntry.letter;
       }
-      style = scopeCss(style, cssId);
-      scopedStyles.push(style);
-    }
 
-    if (fragment.firstChild && fragment.firstChild.nodeType === 1) {
-      fragment.firstChild.setAttribute("data-ch-source", instance.__sourceFile || compName);
+      runtimeChunks.push(`${letter}RUNTIME(document.querySelector('[chid="${compId}"]'), ${JSON.stringify(ctx)});`);
     }
-
-    element.replaceWith(fragment);
-    return true;
   }
 
-  console.warn(chalk.yellow(`${compName} — component could not be loaded (missing body or styles export)`));
-  return false;
+  if (styles) {
+    let cssId = cssScopesMap && cssScopesMap.get(compName);
+    if (!cssId) {
+      cssId = genRandomId(cssScopes, 8, true);
+      cssScopesMap.set(compName, cssId);
+    }
+    if (fragment.children.length === 1 && firstChild.nodeType === 1) {
+      firstChild.classList.add(cssId);
+    }
+    styles = scopeCss(styles, cssId);
+    scopedStyles.push(styles);
+  }
+
+  if (fragment.children.length === 1 && firstChild.nodeType === 1) {
+    firstChild.setAttribute("data-ch-source", compName);
+  }
+
+  element.replaceWith(fragment);
+  return true;
 }
 
 /**

--- a/compiler/component-processor.js
+++ b/compiler/component-processor.js
@@ -409,8 +409,6 @@ export function processComponentElement(
 
         if (!match) return null;
 
-        const params = match[1].trim();
-
         const startIndexBrace = match.index + match[0].length - 1;
 
         let bracesCount = 0;
@@ -433,22 +431,16 @@ export function processComponentElement(
         }
 
         const fullMatch = script.substring(match.index, closingBraceIndex + 1);
-        const body = script.substring(startIndexBrace + 1, closingBraceIndex).trim();
 
-        return {
-          fullMatch,
-          params,
-          body
-        };
+        return fullMatch;
       }
 
-      let runtime = extractRuntime(script).fullMatch;
-
+      let runtime = extractRuntime(script);
       let letterEntry = runtimeMap && runtimeMap.get(compName);
       let letter;
       if (!letterEntry) {
         letter = getNextLetter(letterState);
-        runtime = runtime.replace(RUNTIME_KW, `${letter}r`);
+        runtime = runtime.replace(`${RUNTIME_KW}()`, `${letter}r(self, ctx)`);
         runtimeChunks.push(runtime);
         runtimeMap && runtimeMap.set(compName, { letter });
       } else {

--- a/compiler/component-processor.js
+++ b/compiler/component-processor.js
@@ -196,15 +196,6 @@ function validateChainStructure(parent, sourceFile, sourceContent, parentContent
   }
 }
 
-/**
- * Processes a single component element and inserts it into the DOM
- * @param {Element} element
- * @param {Map} loadedComponents
- * @param {Array} runtimeChunks
- * @param {Array} compIdColl
- * @param {object} letterState - { value: string }
- * @returns {boolean} - true if component was processed, false if not found
- */
 export function processComponentElement(
   element,
   loadedComponents,
@@ -239,7 +230,6 @@ export function processComponentElement(
     return false;
   }
 
-  // Extract props with defaults from component script
   const compProps = extractPropsDefaults(script);
 
   let ctx;
@@ -250,7 +240,6 @@ export function processComponentElement(
     staticCtxRegistry && staticCtxRegistry.set(element, ctx);
   }
 
-  // Apply default values for props not provided on the element
   if (compProps.length > 0) {
     compProps.forEach(({ name, defaultValue }) => {
       if (defaultValue !== undefined && !(name in ctx)) {
@@ -443,7 +432,7 @@ export function processComponentElement(
       for (const [key, value] of Object.entries(runtimeCtx)) {
         ctxDef += `ctx.${key} = ctx.${key}||${JSON.stringify(value)};\n`;
       }
-      // Add defaults from export let declarations
+
       for (const { name, defaultValue } of compProps) {
         if (defaultValue !== undefined) {
           ctxDef += `ctx.${name} = ctx.${name}||${defaultValue};\n`;
@@ -488,14 +477,10 @@ export function processComponentElement(
 
       if (runtime) {
         for (const { name } of compProps) {
-          console.log(`${compName} replacing prop: ${name}`)
           runtime = runtime.replace(name, `ctx.${name}`);
         }
 
-        // Inject ctxDef after props replacement so ctxDef lines aren't double-replaced
         runtime = runtime.replace(/\$runtime\([^)]*\)\s*\{/, match => match + "\n" + ctxDef);
-
-        console.log(runtime)
 
         let letterEntry = runtimeMap && runtimeMap.get(compName);
         let letter;
@@ -534,16 +519,6 @@ export function processComponentElement(
   return true;
 }
 
-/**
- * Processes all components in the app container
- * @param {Element[]} appElements
- * @param {Map} loadedComponents
- * @returns {{
- *   runtimeScript: string,
- *   hasComponents: boolean
- *   scopesCss: CSSString
- * }}
- */
 export function processAllComponents(appElements, loadedComponents, pageSourceFile, pageSourceContent) {
   let runtimeChunks = [];
   let compIdColl = [];
@@ -565,11 +540,6 @@ export function processAllComponents(appElements, loadedComponents, pageSourceFi
   return { runtimeScript, hasComponents, scopesCss };
 }
 
-/**
- * Gets the next letter in sequence or starts with 'a'
- * @param {object} letterState - { value: string }
- * @returns {string}
- */
 function getNextLetter(letterState) {
   if (!letterState.value) {
     letterState.value = "a";

--- a/compiler/component-processor.js
+++ b/compiler/component-processor.js
@@ -225,7 +225,7 @@ export function processComponentElement(
     console.warn(chalk.yellow(`${compName} — component is missing a <template>`));
     return false;
   }
-  
+
   const fragment = JSDOM.fragment(template);
 
   const slotFragment = JSDOM.fragment(elInnerHtml);
@@ -403,13 +403,53 @@ export function processComponentElement(
       script = script.replace(ctxRegex, "ctx");
       script = script.replace(/\$runtime\([^)]*\)\s*{/, match => match + "\n" + ctxDef);
 
+      function extractRuntime(script) {
+        const startRegex = /(?:async\s+)?function\s+\$runtime\(([^)]*)\)\s*\{/;
+        const match = script.match(startRegex);
+
+        if (!match) return null;
+
+        const params = match[1].trim();
+
+        const startIndexBrace = match.index + match[0].length - 1;
+
+        let bracesCount = 0;
+        let closingBraceIndex = -1;
+
+        for (let i = startIndexBrace; i < script.length; i++) {
+          if (script[i] === "{") {
+            bracesCount++;
+          } else if (script[i] === "}") {
+            bracesCount--;
+            if (bracesCount === 0) {
+              closingBraceIndex = i;
+              break;
+            }
+          }
+        }
+
+        if (closingBraceIndex === -1) {
+          throw new Error(`${compName} $runtime function has unclosed curly braces.`);
+        }
+
+        const fullMatch = script.substring(match.index, closingBraceIndex + 1);
+        const body = script.substring(startIndexBrace + 1, closingBraceIndex).trim();
+
+        return {
+          fullMatch,
+          params,
+          body
+        };
+      }
+
+      let runtime = extractRuntime(script).fullMatch;
+
       let letterEntry = runtimeMap && runtimeMap.get(compName);
       let letter;
       if (!letterEntry) {
         letter = getNextLetter(letterState);
-        script = script.replace(RUNTIME_KW, `${letter}r`);
-        console.log(script)
-        runtimeChunks.push(script);
+        runtime = runtime.replace(RUNTIME_KW, `${letter}r`);
+        runtimeChunks.push(runtime);
         runtimeMap && runtimeMap.set(compName, { letter });
       } else {
         letter = letterEntry.letter;
@@ -465,6 +505,7 @@ export function processAllComponents(appElements, loadedComponents, pageSourceFi
     processComponentElement(el, loadedComponents, runtimeChunks, compIdColl, letterState, runtimeMap, cssScopes, cssScopesMap, scopedStyles, [], staticCtxRegistry, pageSourceFile, pageSourceContent);
   });
   const runtimeScript = runtimeChunks.join("\n");
+  console.log(runtimeScript)
   const hasComponents = runtimeChunks.length > 0;
   const scopesCss = beautify.css(scopedStyles.join("\n"));
 

--- a/compiler/component-processor.js
+++ b/compiler/component-processor.js
@@ -399,22 +399,23 @@ export function processComponentElement(
       for (const [key, value] of Object.entries(runtimeCtx)) {
         ctxDef += `ctx.${key} = ctx.${key}||${JSON.stringify(value)};\n`;
       }
-      
+
       script = script.replace(ctxRegex, "ctx");
-      script = script.replace(/RUNTIME\([^)]*\)\s*{/, match => match + "\n" + ctxDef);
+      script = script.replace(/\$runtime\([^)]*\)\s*{/, match => match + "\n" + ctxDef);
 
       let letterEntry = runtimeMap && runtimeMap.get(compName);
       let letter;
       if (!letterEntry) {
         letter = getNextLetter(letterState);
-        script = script.replace(/RUNTIME/g, `${letter}RUNTIME`);
+        script = script.replace(RUNTIME_KW, `${letter}r`);
+        console.log(script)
         runtimeChunks.push(script);
         runtimeMap && runtimeMap.set(compName, { letter });
       } else {
         letter = letterEntry.letter;
       }
 
-      runtimeChunks.push(`${letter}RUNTIME(document.querySelector('[chid="${compId}"]'), ${JSON.stringify(ctx)});`);
+      runtimeChunks.push(`${letter}r(document.querySelector('[chid="${compId}"]'), ${JSON.stringify(ctx)});`);
     }
   }
 
@@ -483,3 +484,6 @@ function getNextLetter(letterState) {
   }
   return letterState.value;
 }
+
+const RUNTIME_KW = "$runtime";
+const RUNTIME_REGEX = new RegExp(RUNTIME_KW, "g");

--- a/compiler/component-processor.js
+++ b/compiler/component-processor.js
@@ -435,19 +435,45 @@ export function processComponentElement(
         return fullMatch;
       }
 
-      let runtime = extractRuntime(script);
-      let letterEntry = runtimeMap && runtimeMap.get(compName);
-      let letter;
-      if (!letterEntry) {
-        letter = getNextLetter(letterState);
-        runtime = runtime.replace(`${RUNTIME_KW}()`, `${letter}r(self, ctx)`);
-        runtimeChunks.push(runtime);
-        runtimeMap && runtimeMap.set(compName, { letter });
-      } else {
-        letter = letterEntry.letter;
+      function extractProps(script) {
+        const propsRegex = /export\s+let\s+([a-zA-Z_$][0-9a-zA-Z_$]*)\s*(?:=\s*([^;]+))?;/g;
+
+        let props = [];
+        let match;
+
+        while ((match = propsRegex.exec(script)) !== null) {
+          props.push(match[1].trim());
+        }
+
+        return props;
       }
 
-      runtimeChunks.push(`${letter}r(document.querySelector('[chid="${compId}"]'), ${JSON.stringify(ctx)});`);
+      let runtime = extractRuntime(script);
+      let props = extractProps(script);
+
+      if (runtime) {
+        if (props.length > 0) {
+          props.forEach(prop => {
+            console.log(`${compName} replacing prop: ${prop}`)
+            runtime = runtime.replace(prop, `ctx.${prop}`);
+          });
+
+          console.log(runtime)
+        }
+
+        let letterEntry = runtimeMap && runtimeMap.get(compName);
+        let letter;
+        if (!letterEntry) {
+          letter = getNextLetter(letterState);
+          runtime = runtime.replace(`${RUNTIME_KW}()`, `${letter}r(self, ctx)`);
+          runtimeChunks.push(runtime);
+          runtimeMap && runtimeMap.set(compName, { letter });
+        } else {
+          letter = letterEntry.letter;
+        }
+
+        runtimeChunks.push(`${letter}r(document.querySelector('[chid="${compId}"]'), ${JSON.stringify(ctx)});`);
+      }
     }
   }
 
@@ -497,7 +523,6 @@ export function processAllComponents(appElements, loadedComponents, pageSourceFi
     processComponentElement(el, loadedComponents, runtimeChunks, compIdColl, letterState, runtimeMap, cssScopes, cssScopesMap, scopedStyles, [], staticCtxRegistry, pageSourceFile, pageSourceContent);
   });
   const runtimeScript = runtimeChunks.join("\n");
-  console.log(runtimeScript)
   const hasComponents = runtimeChunks.length > 0;
   const scopesCss = beautify.css(scopedStyles.join("\n"));
 

--- a/compiler/config.js
+++ b/compiler/config.js
@@ -1,16 +1,6 @@
 import path from "path";
 import { getChocolaConfig } from "../utils.js";
 
-/**
- * Loads and merges Chocola configuration with defaults
- * @param {import("fs").PathLike} rootDir
- * @returns {Promise<{
- *   srcDir: string,
- *   outDir: string,
- *   libDir: string,
- *   emptyOutDir: boolean
- * }>}
- */
 export async function loadConfig(rootDir) {
   const config = await getChocolaConfig(rootDir);
   const bundleConfig = config.bundle || {};
@@ -23,12 +13,6 @@ export async function loadConfig(rootDir) {
   return { srcDir, outDir, libDir, emptyOutDir };
 }
 
-/**
- * Resolves all path directories based on configuration
- * @param {import("fs").PathLike} rootDir
- * @param {object} config
- * @returns {object}
- */
 export function resolvePaths(rootDir, config) {
   return {
     outDir: path.join(rootDir, config.outDir),

--- a/compiler/dom-processor.js
+++ b/compiler/dom-processor.js
@@ -4,20 +4,10 @@ import path from "path";
 import { throwError, protectCurlyBraces, restoreCurlyBraces, compileExpression } from "./utils.js";
 import { readMyFile } from "./fs.js";
 
-/**
- * Creates a JSDOM instance from source index file
- * @param {string} srcIndexContent
- * @returns {JSDOM}
- */
 export function createDOM(srcIndexContent) {
   return new JSDOM(protectCurlyBraces(srcIndexContent));
 }
 
-/**
- * Validates that the index file has an <app> root element
- * @param {Document} doc
- * @throws {Error} if <app> element not found
- */
 export function validateAppContainer(doc) {
   const appContainer = doc.querySelector("app");
   if (!appContainer) {
@@ -26,20 +16,10 @@ export function validateAppContainer(doc) {
   return appContainer;
 }
 
-/**
- * Extracts all child elements from app container
- * @param {Element} appContainer
- * @returns {Element[]}
- */
 export function getAppElements(appContainer) {
   return Array.from(appContainer.querySelectorAll("*"));
 }
 
-/**
- * Extracts context attributes from element (ctx.* attributes)
- * @param {Element} element
- * @returns {object}
- */
 export function extractContextFromElement(element) {
   const ctx = {};
   for (const attr of element.attributes) {
@@ -58,31 +38,16 @@ export function extractContextFromElement(element) {
   return ctx;
 }
 
-/**
- * Serializes and formats DOM to pretty HTML
- * @param {JSDOM} dom
- * @returns {string}
- */
 export async function serializeDOM(dom) {
   const beautify = (await import("js-beautify")).default;
   const finalHtml = restoreCurlyBraces(dom.serialize());
   return beautify.html(finalHtml, { indent_size: 2 });
 }
 
-/**
- * Writes the final HTML to output directory
- * @param {string} html
- * @param {import("fs").PathLike} outDirPath
- */
 export async function writeHTMLOutput(html, outDirPath) {
   await fs.writeFile(path.join(outDirPath, "index.html"), html);
 }
 
-/**
- * Gets all stylesheet and icon links from document
- * @param {Document} doc
- * @returns {{stylesheets: HTMLLinkElement[], icons: HTMLLinkElement[]}}
- */
 export function getAssetLinks(doc) {
   const docLinks = Array.from(doc.querySelectorAll("link"));
   const stylesheets = docLinks.filter(link => link.rel === "stylesheet");
@@ -90,21 +55,10 @@ export function getAssetLinks(doc) {
   return { stylesheets, icons };
 }
 
-/**
- * Writes CSS to output directory
- * @param {string} css
- * @param {import("fs").PathLike} outDirPath
- * @param {string} filename
- */
 export async function writeCSSOutput(css, outDirPath, filename = "scopes.css") {
   await fs.writeFile(path.join(outDirPath, filename), css);
 }
 
-/**
- * Appends a stylesheet link element to document head
- * @param {Document} doc
- * @param {string} filename
- */
 export function appendStylesheetLink(doc, filename) {
   const linkEl = doc.createElement("link");
   linkEl.rel = "stylesheet";
@@ -112,11 +66,6 @@ export function appendStylesheetLink(doc, filename) {
   doc.head.appendChild(linkEl);
 }
 
-/**
- * Appends a script element to document body
- * @param {Document} doc
- * @param {string} filename
- */
 export function appendRuntimeScript(doc, filename) {
   const runtimeScriptEl = doc.createElement("script");
   runtimeScriptEl.type = "module";

--- a/compiler/fs.js
+++ b/compiler/fs.js
@@ -1,12 +1,6 @@
 import { promises as fs } from "fs";
 import { throwError } from "./utils.js";
 
-/**
- * Reads a file and returns its contents as a UTF-8 string
- * @param {import("fs").PathLike} filePath - Path to the file
- * @returns {Promise<string>} - File contents
- * @throws {Error} - If file cannot be read
- */
 export async function readMyFile(filePath) {
   try {
     const data = await fs.readFile(filePath, "utf-8");
@@ -16,11 +10,6 @@ export async function readMyFile(filePath) {
   }
 }
 
-/**
- * Checks if a file exists
- * @param {import("fs").PathLike} filePath - Path to check
- * @returns {Promise<boolean>} - True if file exists, false otherwise
- */
 export async function checkFile(filePath) {
   try {
     await fs.access(filePath);

--- a/compiler/index.js
+++ b/compiler/index.js
@@ -75,15 +75,15 @@ async function setupOutputDirectory(outDirPath, emptyOutDir) {
 
 async function loadAndDisplayComponents(srcComponentsPath) {
   const foundComponents = await getComponents(srcComponentsPath);
-  const { loadedComponents, notDefComps, componentsLib } = foundComponents;
+  const { loadedComponents, notDefComps: emptyComps, componentsLib } = foundComponents;
 
   console.log(`       LOADING COMPONENTS`);
   console.log(chalk.bold.green(">"), "Components found in", chalk.green.underline(srcComponentsPath) + ":");
   console.log("   ", componentsLib, "\n");
 
-  if (notDefComps.length > 0) {
-    console.warn(chalk.bold.yellow("WARNING!"), "The following components don't include a default export:");
-    console.log("   ", notDefComps);
+  if (emptyComps?.length > 0) {
+    console.warn(chalk.bold.yellow("WARNING!"), "The following component files are empty:");
+    console.log("   ", emptyComps);
   }
 
   return loadedComponents;

--- a/compiler/index.js
+++ b/compiler/index.js
@@ -113,7 +113,7 @@ async function processAssets(doc, rootDir, srcDir, outDirPath) {
  * }
  * >} config
  */
-export default async function runtime(rootDir, buildConfig) {
+export default async function compile(rootDir, buildConfig) {
   const isHotReload = buildConfig?.isHotReload || null;
   !isHotReload && logBanner();
 
@@ -261,5 +261,5 @@ export const app = {
  * @example
  * @param {PathLike} __rootdir the directory where your Chocola App is
  */
-  async build(__rootdir) { return runtime(__rootdir) }
+  async build(__rootdir) { return compile(__rootdir) }
 };

--- a/compiler/index.js
+++ b/compiler/index.js
@@ -105,14 +105,6 @@ async function processAssets(doc, rootDir, srcDir, outDirPath) {
   return cssContents
 }
 
-/**
- * Compiles a static build of your Chocola project from the directory provided.
- * @param {import("fs").PathLike} rootDir
- * @param {Object<{
- * isHotReload?: boolean
- * }
- * >} config
- */
 export default async function compile(rootDir, buildConfig) {
   const isHotReload = buildConfig?.isHotReload || null;
   !isHotReload && logBanner();

--- a/compiler/pipeline.js
+++ b/compiler/pipeline.js
@@ -58,14 +58,13 @@ export async function getComponents(libDir) {
 }
 
 /**
- * Loads the project index file (HTML or .choco)
- * If both HTML and .choco files exist, throws an error
+ * Loads the project index file
  * @param {import("fs").PathLike} srcPath - Source directory
  * @returns {Promise<{
  *   srcHtmlFile: string | null,
  *   srcChocoFile: string | null
  * }>}
- * @throws {Error} if both index files exist or .choco is used (not yet supported)
+ * @throws {Error}
  */
 export async function getSrcIndex(srcPath) {
   const srcHtmlPath = path.join(srcPath, "index.html");

--- a/compiler/pipeline.js
+++ b/compiler/pipeline.js
@@ -3,18 +3,6 @@ import { throwError, genRandomId } from "./utils.js";
 import { readMyFile, checkFile } from "./fs.js";
 import path from "path";
 
-/**
- * Discovers and loads all components from a library directory.
- * Components are JavaScript files that start with an uppercase letter.
- * They must have a default export that is a function
- * @param {import("node:fs").PathLike} libDir - Directory containing component files
- * @returns {Promise<{
- *   componentsLib: string[],
- *   loadedComponents: Map<string, object>,
- *   notDefComps: string[]
- * }>}
- * @throws {Error} if libDir cannot be found
- */
 export async function getComponents(libDir) {
   try {
     let componentsLib = [];
@@ -50,15 +38,6 @@ export async function getComponents(libDir) {
   }
 }
 
-/**
- * Loads the project index file
- * @param {import("fs").PathLike} srcPath - Source directory
- * @returns {Promise<{
- *   srcHtmlFile: string | null,
- *   srcChocoFile: string | null
- * }>}
- * @throws {Error}
- */
 export async function getSrcIndex(srcPath) {
   const srcHtmlPath = path.join(srcPath, "index.html");
 
@@ -76,15 +55,6 @@ export async function getSrcIndex(srcPath) {
   }
 }
 
-/**
- * Processes stylesheet links: copies CSS files to output and updates link href
- * @param {HTMLLinkElement} link - The link element to process
- * @param {import("fs").PathLike} rootDir - Root project directory
- * @param {string} srcDir - Source directory name
- * @param {import("fs").PathLike} outDirPath - Output directory path
- * @param {Array} fileIds - Array to track used file IDs
- * @throws {Error} if stylesheet cannot be read or written
- */
 export async function processStylesheet(link, rootDir, srcDir, outDirPath, fileIds) {
   try {
     const href = link.href;
@@ -102,14 +72,6 @@ export async function processStylesheet(link, rootDir, srcDir, outDirPath, fileI
   }
 }
 
-/**
- * Processes icon links: copies icon files to output directory
- * @param {HTMLLinkElement} link - The link element to process
- * @param {import("fs").PathLike} rootDir - Root project directory
- * @param {string} srcDir - Source directory name
- * @param {import("fs").PathLike} outDirPath - Output directory path
- * @throws {Error} if icon cannot be copied
- */
 export async function processIcons(link, rootDir, srcDir, outDirPath) {
   try {
     const href = link.href;
@@ -121,13 +83,6 @@ export async function processIcons(link, rootDir, srcDir, outDirPath) {
   }
 }
 
-/**
- * Copies the static/ directory from source to output.
- * The entire static/ directory tree is copied recursively.
- * Silently skips if static/ does not exist.
- * @param {import("fs").PathLike} srcPath - Source directory path
- * @param {import("fs").PathLike} outDirPath - Output directory path
- */
 export async function copyStaticDir(srcPath, outDirPath) {
   const staticSrc = path.join(srcPath, "static");
   const staticDest = path.join(outDirPath, "static");
@@ -135,6 +90,5 @@ export async function copyStaticDir(srcPath, outDirPath) {
     await fs.access(staticSrc);
     await fs.cp(staticSrc, staticDest, { recursive: true, force: true });
   } catch {
-    // static/ directory doesn't exist — nothing to copy
   }
 }

--- a/compiler/pipeline.js
+++ b/compiler/pipeline.js
@@ -1,5 +1,5 @@
 import { promises as fs } from "fs";
-import { loadWithAssets, throwError, genRandomId } from "./utils.js";
+import { throwError, genRandomId } from "./utils.js";
 import { readMyFile, checkFile } from "./fs.js";
 import path from "path";
 
@@ -19,7 +19,7 @@ export async function getComponents(libDir) {
   try {
     let componentsLib = [];
     let loadedComponents = new Map();
-    let notDefComps = [];
+    let emptyComps = [];
 
     const components = await fs.readdir(libDir);
 
@@ -28,22 +28,15 @@ export async function getComponents(libDir) {
     }
 
     for (const comp of components) {
-      if (!comp.endsWith(".js") || comp[0] !== comp[0].toUpperCase()) continue;
+      if (!comp.endsWith(".html")) continue;
 
       componentsLib.push(comp);
 
-      let module;
       try {
-        module = await loadWithAssets(path.join(libDir, comp));
-
-        if (typeof module.default !== "function") {
-          notDefComps.push(comp);
-          continue;
-        }
-
-        const instance = module.default();
         const compPath = path.join(libDir, comp);
-        instance.__sourceFile = compPath;
+        const instance = await fs.readFile(compPath, "utf-8");
+
+        if (instance === "" || instance.trim().length === 0) emptyComps.push(comp);
 
         loadedComponents.set(comp.toLowerCase(), instance);
       } catch (err) {
@@ -51,7 +44,7 @@ export async function getComponents(libDir) {
       }
     }
 
-    return { componentsLib, loadedComponents, notDefComps };
+    return { componentsLib, loadedComponents, emptyComps };
   } catch (err) {
     throwError(`Failed to load components from ${libDir}: ${err.message}`);
   }

--- a/compiler/runtime-generator.js
+++ b/compiler/runtime-generator.js
@@ -2,12 +2,6 @@ import { promises as fs } from "fs";
 import path from "path";
 import { genRandomId } from "./utils.js";
 
-/**
- * Generates a runtime script file and returns its filename
- * @param {string} runtimeScript - The JavaScript code for runtime
- * @param {import("fs").PathLike} outDirPath
- * @returns {Promise<string>} - filename of the generated runtime script
- */
 export async function generateRuntimeScript(runtimeScript, outDirPath) {
   const fileIds = [];
   const runtimeFilename = "run-" + genRandomId(fileIds, 6) + ".js";

--- a/compiler/utils.js
+++ b/compiler/utils.js
@@ -3,22 +3,11 @@ import path from "path";
 import { pathToFileURL } from "url";
 import chalk from "chalk";
 
-/**
- * Throws a formatted error message and exits
- * @param {string|Error} err - Error message or Error object
- * @throws {Error}
- */
 export function throwError(err) {
   console.log(chalk.red.bold("Error!"), "A fatal error has occurred:\n");
   throw new Error(err);
 }
 
-/**
- * Generates a random ID string
- * @param {Array} collection - Array to track used IDs (prevents duplicates)
- * @param {number} length - Desired length of the ID (default: 10)
- * @returns {string} - Unique random ID
- */
 export function genRandomId(collection = null, length = 10, lettersOnly = false) {
   let id;
   if (lettersOnly) {
@@ -35,14 +24,6 @@ export function genRandomId(collection = null, length = 10, lettersOnly = false)
   }
 }
 
-/**
- * Increments a letter or sequence of letters like Excel columns (a → b, z → aa)
- * @param {string} letters - Letter(s) to increment
- * @returns {string} - Incremented letter(s)
- * @example
- * incrementAlfabet("a") // "b"
- * incrementAlfabet("z") // "aa"
- */
 export function incrementAlfabet(letters) {
   let arr = letters.split("");
   let i = arr.length - 1;
@@ -61,11 +42,6 @@ export function incrementAlfabet(letters) {
   return "a" + arr.join("");
 }
 
-/**
- * Checks if a string is a valid HTTP/HTTPS URL
- * @param {string} str - String to check
- * @returns {boolean} - True if valid web link, false otherwise
- */
 export function isWebLink(str) {
   try {
     const url = new URL(str);
@@ -78,24 +54,12 @@ export function isWebLink(str) {
 const LBRACE_PH = "_%%CHOCOLA-LBRACE%%_";
 const RBRACE_PH = "_%%CHOCOLA-RBRACE%%_";
 
-/**
- * Replaces HTML entities for curly braces with placeholders before JSDOM parsing.
- * This prevents JSDOM from decoding them into literal braces before binding processing.
- * @param {string} html - Raw HTML content
- * @returns {string} - HTML with curly brace entities replaced
- */
 export function protectCurlyBraces(html) {
   return html
     .replace(/&(?:lbrace|#123|#x7B);/gi, LBRACE_PH)
     .replace(/&(?:rcub|#125|#x7D);/gi, RBRACE_PH);
 }
 
-/**
- * Restores curly brace placeholders back to literal characters.
- * Called after binding processing is complete and before final output.
- * @param {string} html - Serialized HTML with placeholders
- * @returns {string} - HTML with literal curly braces restored
- */
 export function restoreCurlyBraces(html) {
   return html
     .replace(/_%%CHOCOLA-LBRACE%%_/g, "{")

--- a/compiler/utils.js
+++ b/compiler/utils.js
@@ -14,64 +14,6 @@ export function throwError(err) {
 }
 
 /**
- * Loads a JavaScript module and inlines asset imports (HTML/CSS files)
- * This allows components to import external template files as strings
- * @param {import("fs").PathLike} filePath - Path to the JavaScript file
- * @returns {Promise<object>} - The imported module
- * @example
- * // Component with asset import
- * import template from "./button.html";
- * export default function Button() { return { body: template }; }
- */
-export async function loadWithAssets(filePath) {
-  let code;
-  try {
-    code = await fs.readFile(filePath, "utf8");
-  } catch (err) {
-    throwError(`Failed to read component file "${filePath}": ${err.message || err}`);
-  }
-
-  const importRegex = /import\s+(\w+)\s+from\s+["'](.+?\.(html|css))["'];?/g;
-
-  const replacements = [];
-  let match;
-  while ((match = importRegex.exec(code))) {
-    const varName = match[1];
-    const relPath = match[2];
-    const absPath = path.resolve(path.dirname(filePath), relPath);
-
-    let content;
-    try {
-      content = await fs.readFile(absPath, "utf8");
-    } catch (err) {
-      throwError(
-        `Failed to read imported file "${relPath}" (resolved to "${absPath}") ` +
-        `for variable "${varName}" in component "${filePath}": ${err.message || err}`
-      );
-    }
-
-    replacements.push({ from: match[0], to: `const ${varName} = ${JSON.stringify(content)};` });
-  }
-
-  for (const { from, to } of replacements) {
-    code = code.replace(from, to);
-  }
-
-  const dataUrl =
-    "data:text/javascript;base64," +
-    Buffer.from(code).toString("base64");
-
-  try {
-    const mod = await import(dataUrl);
-    return mod;
-  } catch (err) {
-    throwError(
-      `Failed to evaluate component "${filePath}": ${err.message || err}`
-    );
-  }
-}
-
-/**
  * Generates a random ID string
  * @param {Array} collection - Array to track used IDs (prevents duplicates)
  * @param {number} length - Desired length of the ID (default: 10)

--- a/documentation/01-introduction/01-overview.md
+++ b/documentation/01-introduction/01-overview.md
@@ -17,8 +17,8 @@ Chocola is a web framework designed for simplicity and modularity. It lets you b
         const number = self.querySelector(".number");
 
         btn.addEventListener("click", () => {
-            ctx.count++;
-            number.textContent = ctx.count;
+            count++;
+            number.textContent = count;
         })
     }
 </script>

--- a/documentation/01-introduction/01-overview.md
+++ b/documentation/01-introduction/01-overview.md
@@ -3,26 +3,36 @@ title: Overview
 description: What is Chocola and why use it
 ---
 
-Chocola is a web framework designed for simplicity and modularity. It lets you build components by compiling JS modules into HTML templates, CSS, and JS logic, keeping your projects clean and optimized.
+Chocola is a web framework designed for simplicity and modularity. It lets you build single-file components (SFCs) — a single `.html` file containing your template, logic, and styles — and compiles them into a clean static site.
 
-```js
-// file: Counter.js
-import body from "./html/counter.html";
-import styles from "./css/counter.css";
+```html
+<!-- file: Counter.html -->
+<script>
+    let self = new HTMLElement;
 
-function RUNTIME(self, ctx) {
-  self.querySelector("button").addEventListener("click", () => {
-    ctx.count++;
-  })
-}
+    export let start = 0;
 
-export default function Counter() {
-  return {
-    body,
-    styles,
-    script: RUNTIME
-  }
-}
+    function $runtime() {
+        const btn = self.querySelector("button");
+        const number = self.querySelector(".number");
+
+        btn.addEventListener("click", () => {
+            ctx.count++;
+            number.textContent = ctx.count;
+        })
+    }
+</script>
+
+<template>
+    <button>Click me</button>
+    <div class="main">
+        <div class="number">{start}</div>
+    </div>
+</template>
+
+<style>
+    button { color: chocolate; }
+</style>
 ```
 
 Chocola handles the compilation for you, outputting a fully functional web app with vanilla JavaScript — no extra libraries needed.

--- a/documentation/01-introduction/02-getting-started.md
+++ b/documentation/01-introduction/02-getting-started.md
@@ -10,8 +10,6 @@ my-app/
 ├── src/
 │   ├── lib/
 │   ├── static/
-│   ├── styles/
-│   ├── routes/
 │   └── index.html
 ├── chocola.config.json
 ├── chocola.server.js

--- a/documentation/01-introduction/02-getting-started.md
+++ b/documentation/01-introduction/02-getting-started.md
@@ -9,8 +9,6 @@ description: Set up a Chocola project from scratch
 my-app/
 ├── src/
 │   ├── lib/
-│   │   ├── css/
-│   │   └── html/
 │   ├── static/
 │   ├── styles/
 │   ├── routes/

--- a/documentation/02-components/01-fundamentals.md
+++ b/documentation/02-components/01-fundamentals.md
@@ -5,120 +5,119 @@ description: Anatomy of a Chocola component — body, styles, and script
 
 In Chocola, everything you build is a component. A component is a combination of HTML, CSS, and JavaScript logic that gets compiled and rendered into your app automatically. Components make your app modular, reusable, and easier to maintain.
 
-Each component is just a JS module that exports three things:
+A component is a single `.html` file with up to three sections:
 
-1. `body` — the HTML template.
-2. `styles` — the CSS for the component (optional).
-3. `script` — the JS logic that runs for the component (optional).
-
-```js
-// file: MyComponent.js
-import body from "path/to/body.html";
-import styles from "path/to/styles.css";
-
-function RUNTIME(self, ctx) {
-  // isolated component logic
-}
-
-export default function MyComponent() {
-  return {
-    body,
-    styles,
-    script: RUNTIME
-  }
-}
-```
-
-- `RUNTIME` is the behavior for your component.
-- `ctx` is an object to store state that persists across renders.
-- `self` is the root DOM element of the component.
-
-Once exported, Chocola automatically injects your component into the `<app>` element of your `index.html`. You can create as many components as you want, and each one stays isolated and reusable.
-
-> TIP: Every component must have a `body`; `styles` and `script` are optional.
-
-## HTML Templates
-
-HTML templates are pieces of HTML that follow Chocola's syntax. They can contain bindings to insert content:
-
-```html
-<!-- my-component.html -->
-<div>
-  <button title={title}>{text}</button>
-  <div class="main">
-    <div class="number">{count}</div>
-  </div>
-</div>
-```
-
-As of now, Chocola only supports one-time substitution bindings, baked at compile-time. Reactive bindings will be added in V3.
-
-## Scoped CSS
-
-CSS imported into a component is scoped to that component:
-
-```css
-/* file: my-component.css */
-button {
-  /* this will only affect <button> elements in this component */
-  color: chocolate;
-}
-```
-
-> Chocola ensures that styles don't leak between components.
-
-## JS RUNTIME
-
-The `RUNTIME` function runs when the component is rendered. It receives:
-- `self` — the root DOM element of the component.
-- `ctx` — an object to store and update state.
-
-```js
-// file: Counter.js
-function RUNTIME(self, ctx) {
-  const button = self.querySelector("button");
-
-  button.addEventListener("click", () => {
-    ctx.count++;
-    button.textContent = ctx.count;
-  });
-}
-```
-
-## New Components (V2)
-
-Chocola 2 will replace the Modular Components with Single File Components (SFC), similar to most modern web frameworks. This is a preview of what a component will look like in the future:
+- `<template>` — the HTML markup.
+- `<style>` — scoped CSS (optional).
+- `<script>` — runtime logic and prop declarations (optional).
 
 ```html
 <!-- file: MyComponent.html -->
 <script>
-    import MyComponent from "path/to/MyComponent.html";
-    import MyStyle from "path/to/my-style.css";
+    let self = new HTMLElement;
 
-    function $props() {
-        return {
-            display: Boolean,
-            title: String || "My Title",
-            label: "My Label"
-        }
-    }
-
-    export let { remove, display, title, label } = $props();
-
-    const self = new HTMLElement;
-    let contents = "Hello";
-    let bgColor = "white";
+    export let title = "Default";
+    export let count = 0;
 
     function $runtime() {
-        // ...
+        // runs once when the component is mounted
     }
 </script>
 
-<void>
-    <!-- Component body -->
-</void>
+<template>
+    <h1>{title}</h1>
+    <p>Count: {count}</p>
+</template>
 
 <style>
-    /* Encapsulated styles */
+    h1 { color: chocolate; }
 </style>
+```
+
+Only `<template>` is required — `<script>` and `<style>` are optional.
+
+## `<template>` — HTML Markup
+
+The template contains the component's HTML. It supports bindings via `{expr}`, conditionals (`if`, `del:if`, `elif`, `else`), `<slot>` for content projection, and `<void>` as a transparent wrapper.
+
+```html
+<template>
+    <h1>{title}</h1>
+    <div if={isVisible}>Conditional content</div>
+    <slot></slot>
+</template>
+```
+
+Bindings are one-time substitutions, baked at compile-time. Reactive bindings are coming in a future version.
+
+## `<style>` — Scoped CSS
+
+CSS placed inside `<style>` is automatically scoped to the component — it won't leak out and affect other components.
+
+```html
+<style>
+    button {
+        color: chocolate;
+    }
+</style>
+```
+
+Use `:root` as a placeholder for the component's root element:
+
+```html
+<style>
+    :root {
+        color: red;
+    }
+</style>
+```
+
+## `<script>` — Props and Runtime
+
+The `<script>` section has three roles:
+
+### 1. Prop declarations with `export let`
+
+Declare component props with optional default values:
+
+```html
+<script>
+    export let display = true;
+    export let title;
+    export let count = 0;
+</script>
+```
+
+Props without a default value (like `title` above) default to `undefined` unless provided by the parent.
+
+### 2. Root element placeholder
+
+```js
+let self = new HTMLElement;
+```
+
+This is a DX placeholder for IDE autocompletion. At compile-time, `self` is replaced with the component's actual root DOM element.
+
+### 3. Runtime function
+
+```js
+function $runtime() {
+    // component logic
+}
+```
+
+`$runtime` runs once after the component is rendered. It receives `self` (the root element) and `ctx` (props and state) as injected parameters — you don't need to declare them in the signature.
+
+```html
+<script>
+    export let label = "Click me";
+    export let count = 0;
+
+    function $runtime() {
+        const btn = self.querySelector("button");
+        btn.addEventListener("click", () => {
+            count++;
+        });
+    }
+</script>
 ```

--- a/documentation/02-components/01-fundamentals.md
+++ b/documentation/02-components/01-fundamentals.md
@@ -106,7 +106,7 @@ function $runtime() {
 }
 ```
 
-`$runtime` runs once after the component is rendered. It receives `self` (the root element) and `ctx` (props and state) as injected parameters — you don't need to declare them in the signature.
+`$runtime` runs once after the component is rendered. It receives `self` (the root element) and `ctx` (props and state) as injected parameters — you don't declare them in the signature.
 
 ```html
 <script>

--- a/documentation/02-components/02-usage.md
+++ b/documentation/02-components/02-usage.md
@@ -7,60 +7,50 @@ Once you have created your Chocola components, you can use them directly in HTML
 
 ## Component Tag Names
 
-- Use the file name of your component (without the `.js` extension) as the HTML tag.
+- Use the filename of your component (without `.html`) as the HTML tag.
 - Component names use PascalCase (e.g., `Counter`, `UserProfile`, `TodoItem`).
 
 ## Passing Props
 
-Props are custom attributes you can pass to a component to provide values to render.
+Props are custom attributes you can pass to a component. They map to `export let` declarations in the component's `<script>`.
 
 ```html
 <Counter start="{5}" label="Clicks"></Counter>
 ```
 
 - Here, `start` and `label` are props.
-- Props are passed as strings by default. Special props like numbers, booleans, or expressions must be wrapped in `{}` to be converted automatically by Chocola, or you can convert them manually inside the component.
+- String values are passed as-is.
+- Expressions, numbers, booleans, and other dynamic values must be wrapped in `{ }` to be evaluated.
 
 ## Accessing Props in the Component
 
-Props are available in the component context (`ctx`) during runtime:
+Props are available inside `$runtime`:
 
-```js
-function RUNTIME(self, ctx) {
-  ctx.count = ctx.start || 0;
+```html
+<script>
+    export let label = "Counter";
+    export let start = 0;
 
-  const button = self.querySelector("button");
-  button.textContent = ctx.label || "Counter";
+    function $runtime() {
+        let count = start;
+        const button = self.querySelector("button");
 
-  button.addEventListener("click", () => {
-    ctx.count++;
-  });
-}
+        button.addEventListener("click", () => {
+            count++;
+        });
+    }
+</script>
 ```
 
-> Note: `ctx` stores both props and component state.
+If a prop is not provided by the parent, its default value is used.
 
-## Example Rendering
+## Example
 
 ```html
 <!-- file: index.html -->
 <app>
-  <Counter title="Increment Count" start="{5}" label="Clicks"></Counter>
+    <Counter title="Increment Count" start="{5}" label="Clicks"></Counter>
 </app>
 ```
 
-After Chocola compiles the app:
-
-```html
-<!-- file: dist/index.html -->
-<app>
-  <div>
-    <button title="Increment Count">Clicks</button>
-    <div class="main">
-      <div class="number">5</div>
-    </div>
-  </div>
-</app>
-```
-
-The component renders with the provided prop values.
+After Chocola compiles the app, the `<Counter>` tag is replaced with the component's rendered output.

--- a/documentation/03-templates/01-basic-markup.md
+++ b/documentation/03-templates/01-basic-markup.md
@@ -15,7 +15,7 @@ Chocola supports standard HTML attributes plus custom ones. JavaScript expressio
 
 ## Component Props
 
-Props are values passed to a component's context (`ctx`). They do not appear as HTML attributes in the DOM.
+Props are values passed to a component's context. They do not appear as HTML attributes in the DOM.
 
 ```html
 <MyComponent text="Some text" color="{myColor}" />

--- a/documentation/04-styling/01-scoped-styles.md
+++ b/documentation/04-styling/01-scoped-styles.md
@@ -7,41 +7,35 @@ Chocola components support scoped styles — CSS included in a component only af
 
 ### Usage
 
-1. Create your CSS file:
+Add a `<style>` tag to your component:
 
-```css
-/* file: my-style.css */
-button {
-  color: white;
-}
+```html
+<!-- file: MyComponent.html -->
+<template>
+    <button>Click me</button>
+</template>
+
+<style>
+    button {
+        color: white;
+    }
+</style>
 ```
 
-2. Import it in your component:
-
-```js
-// file: MyComponent.js
-import body from "path/to/body.html";
-import styles from "./my-style.css";
-
-export default function Button() {
-  return {
-    body,
-    styles
-  }
-}
-```
+The `button` rule above will only apply to `<button>` elements inside this component.
 
 To apply styles to your root element, use `:root` as a placeholder selector:
 
-```css
-/* file: my-style.css */
-:root {
-  color: red;
-}
+```html
+<style>
+    :root {
+        color: red;
+    }
 
-:root:hover {
-  color: blue;
-}
+    :root:hover {
+        color: blue;
+    }
+</style>
 ```
 
 > Scoped styles automatically take priority over global styles inside the component.

--- a/documentation/05-runtime/01-runtime.md
+++ b/documentation/05-runtime/01-runtime.md
@@ -5,57 +5,50 @@ description: Component runtime logic, self, and ctx
 
 ## Script Runtime
 
-Components can export a `script` function that runs once the component is rendered. This is where you add interactivity or logic tied to the component.
+Components can have runtime logic that runs once the component is rendered. This is where you add interactivity or logic tied to the component.
 
-```js
-// file: MyButton.js
-import body from "path/to/my-button.html";
-
-function RUNTIME() {
-  console.log("Component rendered");
-}
-
-export default function Button() {
-  return {
-    body,
-    script: RUNTIME
-  }
-}
+```html
+<script>
+    function $runtime() {
+        console.log("Component rendered");
+    }
+</script>
 ```
 
 ## Context
 
-The script function receives context to safely access component data and DOM elements:
+The runtime function receives access to component data and DOM elements through injected variables:
 
 - `self` — the root DOM element of the component.
-- `ctx` — contains props and other dynamic values passed to the component. You can also define default values.
+- `ctx` — contains props and other dynamic values.
+
+> You don't declare `self` and `ctx` as parameters — they are injected automatically at compile-time.
 
 ### Example with `self` and `ctx`
 
-```js
-// file: Counter.js
-import body from "./html/counter.html";
+```html
+<script>
+    let self = new HTMLElement;
+    export let count = 0;
 
-function RUNTIME(self, ctx = { count: 0 }) {
-  const numDisplay = self.querySelector("#number");
+    function $runtime() {
+        const numDisplay = self.querySelector("#number");
 
-  self.addEventListener("click", () => {
-    if (numDisplay) {
-      numDisplay.textContent = parseInt(numDisplay.textContent) + 1;
+        self.addEventListener("click", () => {
+            if (numDisplay) {
+                numDisplay.textContent = parseInt(numDisplay.textContent) + 1;
+            }
+        });
     }
-  });
-}
+</script>
 
-export default function Button() {
-  return {
-    body,
-    script: RUNTIME
-  }
-}
+<template>
+    <div id="number">{count}</div>
+</template>
 ```
 
 ## Best Practices
 
 - Always manipulate elements inside `self` to prevent conflicts when multiple instances of a component are rendered.
-- Use `ctx` to pass dynamic data or props from the parent component or HTML attributes.
+- Use `$runtime` to store state that persists across renders.
 - Avoid manipulating the global `document` directly inside component scripts.

--- a/documentation/05-runtime/01-runtime.md
+++ b/documentation/05-runtime/01-runtime.md
@@ -1,6 +1,6 @@
 ---
 title: Runtime
-description: Component runtime logic, self, and ctx
+description: Component runtime logic
 ---
 
 ## Script Runtime
@@ -24,7 +24,7 @@ The runtime function receives access to component data and DOM elements through 
 
 > You don't declare `self` and `ctx` as parameters — they are injected automatically at compile-time.
 
-### Example with `self` and `ctx`
+### Example with `self`
 
 ```html
 <script>

--- a/documentation/06-architecture/01-compiler-flow.md
+++ b/documentation/06-architecture/01-compiler-flow.md
@@ -34,11 +34,8 @@ description: How the Chocola compiler works internally
 ### 3. Component Discovery (`compiler/pipeline.js`)
 
 `getComponents(libDir)`:
-- Reads all `.js` files in the components directory
-- Only processes files starting with an uppercase letter (e.g., `Button.js`)
-- Imports each module (inlining `.html`/`.css` imports via `loadWithAssets`)
-- Calls the default export function to get the component instance
-- Stores `__sourceFile` on each instance for error reporting
+- Reads all `.html` files in the components directory
+- Loads each file as a raw HTML string
 - Returns a `Map<lowercase-filename, instance>`
 
 ### 4. DOM Processing (`compiler/dom-processor.js`)
@@ -76,7 +73,7 @@ For each element inside `<app>`:
     - Simple selectors (`.foo`) generate both AND-scoped (`.cssId.foo`) and descendant-scoped (`.cssId .foo`) variants
     - Selectors with combinators use descendant scoping only
     - `:root` and `:root.class` scope to the root element only
-11. **Runtime Chunk** — generates a runtime function call: `aRUNTIME(el, ctx)`
+11. **Runtime Chunk** — generates a runtime function call: `ar(el, ctx)` (the letter prefix is auto-incremented per component)
 12. **Recursion** — processes nested components within the current component (with cycle detection via `renderChain`)
 
 ### 6. Runtime Generation (`compiler/runtime-generator.js`)
@@ -110,8 +107,8 @@ compiler/index.js
 
 ## Key Concepts
 
-- **Components**: ES modules with default export returning `{ body, script, styles, effects }`
-- **Asset inlining**: `.html`/`.css` imports in components are inlined at build time via `loadWithAssets`
+- **Components**: Single-file `.html` components with `<template>`, `<script>`, and `<style>` sections
+- **File-based loading**: `.html` component files are loaded as raw strings and parsed by the compiler
 - **CSS Scoping**: Component styles are scoped by rewriting selectors under a unique CSS class ID. Both root and descendant matching via dual selectors (AND + descendant).
 - **Runtime scripts**: Components with dynamic behavior get a unique ID and a runtime call that re-attaches event listeners/effects on page load
 - **Conditional chains**: `if`/`del:if`/`elif`/`else` form sibling chains tracked per-parent; validated structurally before rendering with file location (line included when the error is within the same source file)

--- a/documentation/06-architecture/01-compiler-flow.md
+++ b/documentation/06-architecture/01-compiler-flow.md
@@ -50,8 +50,8 @@ description: How the Chocola compiler works internally
 For each element inside `<app>`:
 
 1. **Match** — checks if tag name corresponds to a loaded component
-2. **Context** — extracts attributes as context (`ctx.*`)
-3. **Chain validation** — validates `if`/`elif`/`else`/`del:if` structure on both slot content and component body separately before slot replacement, throwing with file location on violation
+2. **Context** — extracts attributes as context
+3. **Chain validation** — validates `if`/`elif`/`else`/`del:if` structure on both slot content and component body separately, throwing with file location on violation
 4. **Template** — renders component body via JSDOM fragment
 5. **Slots** — replaces `<slot>` elements with the original inner HTML
 6. **Attribute interpolation** — evaluates `{expr}` in attributes using `with(ctx)`

--- a/documentation/07-reference/01-faq.md
+++ b/documentation/07-reference/01-faq.md
@@ -23,21 +23,27 @@ The `<app>` element is the landing zone where Chocola drops all your compiled co
 
 ### What does a component look like?
 
-A component is a JavaScript file that exports a function returning an object with up to three keys: `body` (your HTML), `styles` (your CSS), and `script` (your logic). Only `body` is required.
+A component is a single `.html` file with up to three sections: `<template>` (required), `<script>` (optional), and `<style>` (optional).
 
-```js
-// file: Card.js
-import body from "./html/card.html";
-import styles from "./css/card.css";
+```html
+<!-- file: Card.html -->
+<script>
+    export let title = "Card";
+</script>
 
-export default function Card() {
-  return { body, styles };
-}
+<template>
+    <h1>{title}</h1>
+    <slot></slot>
+</template>
+
+<style>
+    h1 { color: chocolate; }
+</style>
 ```
 
 ### How do I use a component on a page?
 
-Use the component's filename as an HTML tag, written in PascalCase. A file called `UserCard.js` becomes `<UserCard></UserCard>` in your HTML. Chocola replaces that tag with the component's rendered output at compile time. Component names must be PascalCase (first letter capitalized).
+Use the component's filename (without `.html`) as an HTML tag, written in PascalCase. A file called `UserCard.html` becomes `<UserCard></UserCard>` in your HTML. Chocola replaces that tag with the component's rendered output at compile time. Component names should be PascalCase (first letter capitalized).
 
 ### Can a component render content passed into it?
 
@@ -69,7 +75,7 @@ Inside the component's `script`, you access those values through the `ctx` objec
 
 ### How do state and reactivity work?
 
-Reactivity and state will be added in Chocola 3. As of now, manually update contents via components' `RUNTIME()` function and global scripts.
+Reactivity and state will be added in Chocola 3. As of now, manually update contents via components' `$runtime()` function and global scripts.
 
 ## Templates & Logic
 
@@ -108,7 +114,6 @@ Link a stylesheet the normal way in your `src/index.html` `<head>`. Those styles
 
 Once, right after the component has been rendered into the DOM. It's the right place to attach event listeners, kick off fetches, set up timers, or anything else that needs the HTML to be there already.
 
-### What are `self` and `ctx`?
+### What is `self`?
 
 - `self` is the root DOM node of your component instance. Always use `self.querySelector()` instead of `document.querySelector()` to avoid bugs when multiple instances of the same component exist.
-- `ctx` is where your props and state live. You can read props from it, write new state to it, and set default values: `function RUNTIME(self, ctx = { count: 0 })`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chocola",
-  "version": "2.0.0-next.3",
+  "version": "2.0.0-next.4",
   "description": "The sweetest way to build the web",
   "keywords": [
     "web",

--- a/utils.js
+++ b/utils.js
@@ -2,11 +2,6 @@ import { promises as fs } from "fs";
 import path from "path";
 import { throwError } from "./compiler/utils.js";
 
-/**
- * Returns `chocola.config.json` as an object.
- * @param {import("fs").PathLike} __rootdir 
- * @returns {Object}
- */
 export async function getChocolaConfig(__rootdir) {
     try {
         const config = await fs.readFile(path.join(__rootdir, "chocola.config.json"), "utf-8");


### PR DESCRIPTION
- Added Chocola SFCs [#46]
  - Now Chocola components are `.html` files with `<script>`, `<template>` (required), and `<styles>` tags
  - Props and their default values are now declared at the top level of `<script>` as `export let prop = defaultValue`; default values are still optional
  - `RUNTIME(self, ctx)` function replaced with `$runtime()`
  - Implemented `let self = new HTMLElement` as a DX placeholder.

- Updated `documentation/` and `README.md`
- Removed comments and JSDocs the user can't see
- Changed the main function of `compiler/index.js` from `runtime` to `compile`