### PR TITLE
Runtime

### DIFF
--- a/compiler/component-processor.js
+++ b/compiler/component-processor.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { JSDOM } from "jsdom";
 import { protectCurlyBraces } from "../utils.js";
 import { genRandomId, incrementAlfabet, throwError, deterministicHash } from "./utils.js";
@@ -12,7 +13,7 @@ import chalk from "./chalk.js";
 
 
 class ProcessContext {
-  constructor(loadedComponents, runtimeChunks, compIdColl, letterState, runtimeMap, cssScopes, cssScopesMap, scopedStyles, staticCtxRegistry) {
+  constructor(loadedComponents, runtimeChunks, compIdColl, letterState, runtimeMap, cssScopes, cssScopesMap, scopedStyles, staticCtxRegistry, csrClasses) {
     this.loadedComponents = loadedComponents;
     this.runtimeChunks = runtimeChunks;
     this.compIdColl = compIdColl;
@@ -22,7 +23,99 @@ class ProcessContext {
     this.cssScopesMap = cssScopesMap;
     this.scopedStyles = scopedStyles;
     this.staticCtxRegistry = staticCtxRegistry;
+    this.csrClasses = csrClasses;
   }
+}
+
+function escapeForTemplateLiteral(str) {
+  return str.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\${/g, "\\${");
+}
+
+function generateCSRClass(compName, cx, explicitClassName) {
+  if (cx.csrClasses.has(compName)) return;
+
+  let instance = cx.loadedComponents.get(compName);
+  if (!instance) return;
+
+  instance = protectCurlyBraces(instance);
+  const dom = new JSDOM(instance);
+  const doc = dom.window.document;
+  const script = doc.querySelector("script")?.innerHTML;
+  const template = doc.querySelector("template")?.innerHTML;
+  const styles = doc.querySelector("style")?.innerHTML;
+
+  if (!template) return;
+
+  const compProps = extractPropsDefaults(script);
+  const topFuncSrc = extractTopLevelFunctions(script || "", RUNTIME_KW);
+  let runtime = extractRuntime(script || "", compName);
+
+  if (!cx.cssScopesMap.has(compName)) {
+    cx.cssScopesMap.set(compName, deterministicHash(compName, 8));
+  }
+  const cssId = cx.cssScopesMap.get(compName);
+
+  if (styles) {
+    cx.scopedStyles.push(scopeCss(styles, cssId));
+  }
+
+  const childMappings = [];
+  const bindVarNames = new Set();
+  const templateDoc = JSDOM.fragment(template);
+  const seenTags = new Set();
+  for (const el of templateDoc.querySelectorAll("*")) {
+    const tag = el.tagName.toLowerCase();
+    if (!seenTags.has(tag)) {
+      seenTags.add(tag);
+      const childCompName = tag + ".html";
+      if (cx.loadedComponents.has(childCompName)) {
+        generateCSRClass(childCompName, cx);
+        const childClassName = childCompName.replace(".html", "").replace(/^\w/, c => c.toUpperCase());
+        childMappings.push({ tag, compClass: childClassName });
+      }
+    }
+    for (const attr of el.attributes) {
+      if (attr.name.startsWith("bind:")) {
+        bindVarNames.add(attr.value);
+      }
+    }
+  }
+
+  let csrRuntimeSource = null;
+  if (runtime) {
+    let injectCode = "";
+    for (const { name, defaultValue } of compProps) {
+      if (defaultValue !== undefined) {
+        injectCode += `let ${name} = ctx.${name}||${defaultValue};\n`;
+      } else {
+        injectCode += `let ${name} = ctx.${name};\n`;
+      }
+    }
+    for (const varName of bindVarNames) {
+      if (varName !== "self") {
+        injectCode += `let ${varName} = ctx.${varName};\n`;
+      }
+    }
+    if (topFuncSrc.length > 0) {
+      injectCode += "\n" + topFuncSrc.join("\n\n") + "\n";
+    }
+    runtime = runtime.replace(/\$runtime\([^)]*\)\s*\{/, match => match + "\n" + injectCode);
+    runtime = runtime.replace(`${RUNTIME_KW}()`, `function(self, ctx)`);
+    csrRuntimeSource = runtime.replace(/^(async\s+)?function\s+\w+/, "$1function");
+  }
+
+  const className = explicitClassName || compName.replace(".html", "").replace(/^\w/, c => c.toUpperCase());
+  const propsObj = {};
+  for (const { name, defaultValue } of compProps) {
+    propsObj[name] = defaultValue !== undefined ? defaultValue : null;
+  }
+
+  const childrenPart = childMappings.length > 0
+    ? ",\n      children: [" + childMappings.map(m => `{tag:"${m.tag}",compClass:${m.compClass}}`).join(",") + "]"
+    : "";
+  const runtimePart = csrRuntimeSource ? `,\n      runtime: ${csrRuntimeSource}` : "";
+  const classDef = `class ${className} extends ChocolaComponent {\n  constructor() {\n    super({\n      template: \`${escapeForTemplateLiteral(template)}\`,\n      hash: "${cssId}",\n      props: ${JSON.stringify(propsObj)}${runtimePart}${childrenPart}\n    });\n  }\n}`;
+  cx.csrClasses.set(compName, classDef);
 }
 
 
@@ -51,6 +144,17 @@ export function processComponentElement(
   if (!template) {
     console.warn(chalk.yellow(`${compName} — component is missing a <template>`));
     return false;
+  }
+
+  if (script) {
+    const importRegex = /import\s+(\w+)\s+from\s+['"]([^'"]+)['"]\s*;?\s*/g;
+    script = script.replace(importRegex, (_, importedName, importPath) => {
+      const importedCompName = path.basename(importPath).toLowerCase();
+      if (cx.loadedComponents.has(importedCompName)) {
+        generateCSRClass(importedCompName, cx, importedName);
+      }
+      return "";
+    });
   }
 
   const compProps = extractPropsDefaults(script);
@@ -213,6 +317,7 @@ export function processComponentElement(
     interpolateNode(child, ctxProxy)
   });
 
+  let csrRuntimeSource = null;
   const firstChild = fragment.children[0];
 
   if (firstChild && firstChild.nodeType === 1) {
@@ -272,6 +377,7 @@ export function processComponentElement(
           runtime = runtime.replace(/\$runtime\([^)]*\)\s*\{/, match => match + "\n" + injectCode);
 
           runtime = runtime.replace(`${RUNTIME_KW}()`, `${letter}r(self, ctx)`);
+          csrRuntimeSource = runtime.replace(/^function\s+\w+/, "function");
           cx.runtimeChunks.push(runtime);
           cx.runtimeMap && cx.runtimeMap.set(compName, { letter });
         } else {
@@ -296,14 +402,33 @@ export function processComponentElement(
     cx.scopedStyles.push(styles);
   }
 
+  if (csrRuntimeSource && !cx.csrClasses.has(compName)) {
+    generateCSRClass(compName, cx);
+  }
+
   element.replaceWith(fragment);
   return true;
 }
 
 export function processAllComponents(appElements, loadedComponents, pageSourceFile, pageSourceContent) {
   const cx = new ProcessContext(
-    loadedComponents, [], [], { value: null }, new Map(), [], new Map(), [], new Map()
+    loadedComponents, [], [], { value: null }, new Map(), [], new Map(), [], new Map(), new Map()
   );
+
+  for (const [compName, instance] of cx.loadedComponents) {
+    const script = instance.match(/<script>([\s\S]*?)<\/script>/i);
+    if (script) {
+      const importRegex = /import\s+(\w+)\s+from\s+['"]([^'"]+)['"]\s*;?\s*/g;
+      let match;
+      while ((match = importRegex.exec(script[1])) !== null) {
+        const importedName = match[1];
+        const importedCompName = path.basename(match[2]).toLowerCase();
+        if (cx.loadedComponents.has(importedCompName)) {
+          generateCSRClass(importedCompName, cx, importedName);
+        }
+      }
+    }
+  }
 
   appElements.forEach(el => {
     if (!el.isConnected) return;
@@ -312,13 +437,14 @@ export function processAllComponents(appElements, loadedComponents, pageSourceFi
   const runtimeScript = cx.runtimeChunks.join("\n");
   const hasComponents = cx.runtimeChunks.length > 0;
   const scopesCss = cx.scopedStyles.join("\n");
+  const csrClasses = [...cx.csrClasses.values()].join("\n\n");
 
   const hashMap = {};
   for (const [compName, hash] of cx.cssScopesMap) {
     hashMap[compName] = hash;
   }
 
-  return { runtimeScript, hasComponents, scopesCss, hashMap };
+  return { runtimeScript, hasComponents, scopesCss, hashMap, csrClasses };
 }
 
 function getNextLetter(letterState) {

--- a/compiler/dom-processor.js
+++ b/compiler/dom-processor.js
@@ -54,7 +54,6 @@ export function getScriptElements(doc) {
 
 export function appendRuntimeScript(doc, filename) {
   const runtimeScriptEl = doc.createElement("script");
-  runtimeScriptEl.type = "module";
   runtimeScriptEl.src = "./" + filename;
   doc.body.appendChild(runtimeScriptEl);
 }

--- a/compiler/index.js
+++ b/compiler/index.js
@@ -209,8 +209,9 @@ export default async function compile(rootDir, buildConfig) {
   processPageConditionals(appContainer);
 
   const appElements = getAppElements(appContainer);
-  const { runtimeScript, scopesCss, hashMap } = processAllComponents(appElements, loadedComponents, pageSourcePath, srcIndexContent);
-  const runtimeFilename = await generateRuntimeScript(runtimeScript, paths.outDir);
+  const { runtimeScript, scopesCss, hashMap, csrClasses } = processAllComponents(appElements, loadedComponents, pageSourcePath, srcIndexContent);
+  const csrSource = await fs.readFile(new URL("../runtime/index.js", import.meta.url), "utf-8");
+  const runtimeFilenames = await generateRuntimeScript(runtimeScript, paths.outDir, csrSource, csrClasses);
   await processAssets(doc, rootDir, config.srcDir, paths.outDir);
 
   if (scopesCss) {
@@ -219,7 +220,9 @@ export default async function compile(rootDir, buildConfig) {
     appendStylesheetLink(doc, fileName);
   };
 
-  appendRuntimeScript(doc, runtimeFilename);
+  for (const name of runtimeFilenames) {
+    appendRuntimeScript(doc, name);
+  }
   const html = await serializeDOM(dom);
   await writeHTMLOutput(html, paths.outDir);
 

--- a/compiler/runtime-generator.js
+++ b/compiler/runtime-generator.js
@@ -2,12 +2,29 @@ import { promises as fs } from "fs";
 import path from "path";
 import { genRandomId } from "./utils.js";
 
-export async function generateRuntimeScript(runtimeScript, outDirPath) {
+export async function generateRuntimeScript(runtimeScript, outDirPath, csrSource, csrClasses) {
   const fileIds = [];
-  const runtimeFilename = "run-" + genRandomId(fileIds, 6) + ".js";
-  const runtimeFileContents = `document.addEventListener("DOMContentLoaded", () => {${runtimeScript}})`;
+  const filenames = [];
 
-  await fs.writeFile(path.join(outDirPath, runtimeFilename), runtimeFileContents);
+  if (csrSource) {
+    const name = "run-" + genRandomId(fileIds, 6) + ".js";
+    const source = csrSource.replace(/^export\s+\{?\s*[^}]+\s*}?\s*;?\s*$/m, "");
+    await fs.writeFile(path.join(outDirPath, name), source);
+    filenames.push(name);
+  }
 
-  return runtimeFilename;
+  if (csrClasses) {
+    const name = "run-" + genRandomId(fileIds, 6) + ".js";
+    await fs.writeFile(path.join(outDirPath, name), csrClasses);
+    filenames.push(name);
+  }
+
+  if (runtimeScript) {
+    const name = "run-" + genRandomId(fileIds, 6) + ".js";
+    const content = `document.addEventListener("DOMContentLoaded", () => {${runtimeScript}})`;
+    await fs.writeFile(path.join(outDirPath, name), content);
+    filenames.push(name);
+  }
+
+  return filenames;
 }

--- a/documentation/05-runtime/01-runtime.md
+++ b/documentation/05-runtime/01-runtime.md
@@ -1,5 +1,5 @@
 ---
-title: Runtime
+title: $runtime
 description: Component runtime logic
 ---
 

--- a/documentation/05-runtime/02-components-api.md
+++ b/documentation/05-runtime/02-components-api.md
@@ -1,0 +1,82 @@
+---
+title: Components API
+description: Client-side rendering components
+---
+
+In Chocola you aren't limited to static renders of your components — you can also instantiate them during runtime using the components API.
+
+## Instantiating a new component
+
+Create a new instance in memory by importing a component in your script.
+
+```js
+import ChatBubble from "./ChatBubble.html";
+
+let self = new HTMLElement;
+
+function createBubble() {
+    // reference to your new instance
+    const newBubble = new ChatBubble();
+}
+```
+
+## mount
+
+To mount a new instance of a component in your app, use the `mount(target, props)` method of the components API.
+
+```js
+import ChatBubble from "./ChatBubble.html";
+
+let self = new HTMLElement;
+
+function createBubble() {
+    const newBubble = new ChatBubble();
+
+    // append to the root element
+    newBubble.mount(self, { msg: "Hi!" })
+}
+```
+
+Props passed to `mount()` override the defaults.
+
+## update
+
+To change the values of the props of an instantiated component, use the `update(props)` method.
+
+```js
+import SendButton from "./SendButton.html";
+
+let self = new HTMLElement;
+
+function $runtime() {
+    const sendBtn = new SendButton();
+    sendBtn.mount(self, { available: true });
+
+    // re-renders the component with new values
+    sendBtn.update({ available: false });
+}
+```
+
+The component tears down and re-renders in place with the new context.
+
+## remove
+
+For removing a instantiated component from your app, use the `remove()` method.
+
+```js
+import ChatBubble from "./ChatBubble.html";
+
+let self = new HTMLElement;
+
+function createBubble() {
+    const newBubble = new ChatBubble();
+    newBubble.mount(self, { msg: "Hi!" });
+
+    // remove the component from your app
+    setTimeout(() => {
+        newBubble.remove();
+    }, 5000)
+}
+```
+
+All tracked event listeners are cleaned up and the DOM element is detached.

--- a/documentation/05-runtime/03-building-components.md
+++ b/documentation/05-runtime/03-building-components.md
@@ -1,0 +1,66 @@
+---
+title: Building components
+description: Creating new components during runtime
+---
+
+Chocola components can be created dynamically in the browser using the `ChocolaComponent` class.
+You will rarely use this method since all your components in source code are already compiled in the final build.
+
+## Creating a component
+
+Extend `ChocolaComponent` with a template, CSS hash, runtime function, and default props:
+
+```js
+class Counter extends ChocolaComponent {
+  constructor() {
+    super({
+      template: `
+        <div>
+          <button bind:self="btn">Clicked {count} times</button>
+        </div>
+      `,
+      hash: "xqkfybnh",
+      props: { count: 0 },
+      runtime(self, ctx) {
+        ctx.btn.addEventListener("click", () => {
+          ctx.count++;
+          ctx.btn.textContent = "Clicked " + ctx.count + " times";
+        });
+      }
+    });
+  }
+}
+```
+
+## Usage
+
+Use your created components the same way you would use the compiled ones.
+
+## Full example
+
+```js
+class Greeting extends ChocolaComponent {
+  constructor() {
+    super({
+      template: `
+        <div class="greeting">
+          <h1>Hello, {name}!</h1>
+          <p bind:self="desc">{role}</p>
+        </div>
+      `,
+      hash: "abc12345",
+      props: { name: "World", role: "user" },
+      runtime(self, ctx) {
+        console.log("Greeting mounted:", ctx.name);
+      }
+    });
+  }
+}
+
+const greeting = new Greeting();
+greeting.mount(document.body, { name: "Alice", role: "admin" });
+
+setTimeout(() => {
+  greeting.update({ name: "Bob", role: "moderator" });
+}, 3000);
+```

--- a/documentation/06-architecture/01-compiler-flow.md
+++ b/documentation/06-architecture/01-compiler-flow.md
@@ -68,17 +68,36 @@ For each element inside `<app>`:
    - `<void elif={expr}>` — chain-aware alternative
    - `<void else>` — chain-aware fallback
    - `<void>` — always renders children unwrapped (fragment-like)
-9. **Runtime ID** — if the component has `script` or `effects`, assigns a unique `chid` attribute
-10. **CSS Scoping** — every component gets a deterministic hash class on its root element derived from the component filename. If the component has `<style>`, the selectors are rewritten under that class:
+9. **Import scanning** — scans component `<script>` for `import X from "./Y.html"` statements. For each match, resolves the imported component by basename, calls `generateCSRClass()` to produce a CSR subclass for it, and strips the import line from the script.
+10. **Runtime ID** — if the component has `script` or `effects`, assigns a unique `chid` attribute
+11. **CSS Scoping** — every component gets a deterministic hash class on its root element derived from the component filename. If the component has `<style>`, the selectors are rewritten under that class:
     - Simple selectors (`.foo`) generate both AND-scoped (`.cssId.foo`) and descendant-scoped (`.cssId .foo`) variants
     - Selectors with combinators use descendant scoping only
     - `:root` and `:root.class` scope to the root element only
-11. **Runtime Chunk** — generates a runtime function call: `ar(el, ctx)` (the letter prefix is auto-incremented per component)
-12. **Recursion** — processes nested components within the current component (with cycle detection via `renderChain`)
+12. **Runtime Chunk** — generates a runtime function call: `ar(el, ctx)` (the letter prefix is auto-incremented per component)
+13. **CSR Class** — if the component has a `$runtime` function and a CSR class hasn't already been generated (e.g., via import scanning), generates a `ChocolaComponent` subclass for client-side dynamic instantiation. The class name is derived from the filename (first letter capitalized), or from the import identifier when triggered by an `import` statement.
+14. **Recursion** — processes nested components within the current component (with cycle detection via `renderChain`)
 
 ### 6. Runtime Generation (`compiler/runtime-generator.js`)
 
-Wraps all runtime chunks in `DOMContentLoaded` and writes to `run-<random>.js`.
+- Reads the self-contained `ChocolaComponent` base class source from `runtime/index.js` (resolved relative to the compiler via `new URL("../runtime/index.js", import.meta.url)`)
+- Strips the `export` statement (output is a non-module script so the class is globally accessible)
+- Writes three separate `run-<random>.js` files: base class, CSR subclasses, SSG `DOMContentLoaded` chunks
+
+### 6a. CSR Class Generation (`compiler/component-processor.js` — `generateCSRClass`)
+
+Produces a `ChocolaComponent` subclass for any loaded component by name:
+
+1. Loads the component instance (raw HTML) from `loadedComponents`
+2. Parses with JSDOM to extract `<script>`, `<template>`, `<style>`
+3. Extracts props defaults and the `$runtime` function (if any)
+4. If `$runtime` exists: injects prop variable declarations (with defaults) and top-level helper function definitions before the runtime body, then rewrites the function signature to `function(self, ctx)`
+5. Assigns or reuses a deterministic CSS hash for the component
+6. Scopes and collects styles
+7. Emits a class definition: `class X extends ChocolaComponent { constructor() { super({ template, hash, props, runtime?, children? }) } }`
+8. Stores the class definition in `cx.csrClasses` keyed by lowercased component filename
+
+The class name respects the original import casing when triggered by an `import` statement (e.g., `import CommonButton from "./CommonButton.html"` produces `class CommonButton`). When generated from HTML tag usage, the name is derived from the filename with only the first letter capitalized.
 
 ### 7. Asset Processing (`compiler/dom-processor.js` + `compiler/pipeline.js`)
 
@@ -89,7 +108,7 @@ Wraps all runtime chunks in `DOMContentLoaded` and writes to `run-<random>.js`.
 
 ### 8. Output (`compiler/dom-processor.js`)
 
-- Appends runtime `<script>` tag to document body
+- Appends runtime `<script>` tags to document body
 - Serializes and beautifies the final HTML
 - Writes `index.html` to output directory
 - Writes generated CSS and JS files alongside it
@@ -98,12 +117,15 @@ Wraps all runtime chunks in `DOMContentLoaded` and writes to `run-<random>.js`.
 ## Data Flow Diagram
 
 ```
+runtime/index.js          → Self-contained ChocolaComponent base class (no parser imports, browser-safe)
+
 compiler/index.js
-  ├─ config.js          → loadConfig + resolvePaths
-  ├─ pipeline.js        → getComponents, getSrcIndex, processStylesheet, processIcons, copyStaticDir
-  ├─ dom-processor.js   → createDOM, validateAppContainer, getAppElements, serializeDOM, writeHTMLOutput, appendRuntimeScript
-  ├─ component-processor.js → validateChainStructure, processAllComponents, processComponentElement, scopeCss
-  ├─ runtime-generator.js → generateRuntimeScript
+  ├─ config.js            → loadConfig + resolvePaths
+  ├─ pipeline.js          → getComponents, getSrcIndex, processStylesheet, processIcons, copyStaticDir
+  ├─ dom-processor.js     → createDOM, validateAppContainer, getAppElements, serializeDOM, writeHTMLOutput, appendRuntimeScript
+  ├─ component-processor.js → validateChainStructure, processAllComponents, processComponentElement,
+  │                          generateCSRClass (CSR subclass generation), scopeCss
+  ├─ runtime-generator.js → generateRuntimeScript — reads runtime/index.js, writes separate run-*.js files for base class, CSR classes, and SSG calls
   └─ .chocola/hashes.json → component-to-hash reference map (written after build)
 ```
 
@@ -114,5 +136,8 @@ compiler/index.js
 - **CSS Scoping**: Component styles are scoped by rewriting selectors under a deterministic hash class derived from the component filename. The hash class is always present on every component's root element, even without styles, serving as a stable component identifier. Both root and descendant matching via dual selectors (AND + descendant).
 - **Hash reference map**: `.chocola/hashes.json` is written after each build, mapping component filenames to their hash classes for debugging. It is auto-generated and should be gitignored.
 - **Runtime scripts**: Components with dynamic behavior get a unique ID and a runtime call that re-attaches event listeners/effects on page load
+- **Client-Side Rendering (CSR)**: The `ChocolaComponent` base class (`runtime/index.js`) allows dynamic component instantiation in the browser via `mount`, `remove`, and `update` methods. It supports `bind:*` attributes, conditionals, slots, expression interpolation, and automatic event-listener cleanup.
+- **Component imports**: Component `<script>` blocks can use `import X from "./Y.html"` syntax. The compiler resolves these imports to known components, generates CSR subclasses for them, and strips the import lines from the build output. Imported components can be instantiated with `new X().mount(target, props)` in the `$runtime` function.
+- **CSR class naming**: When triggered by an `import` statement, the generated class matches the imported identifier casing (e.g., `import CommonButton` → `class CommonButton`). When generated from HTML tag usage, the name is derived from the filename with only the first letter capitalized.
 - **Conditional chains**: `if`/`del:if`/`elif`/`else` form sibling chains tracked per-parent; validated structurally before rendering with file location (line included when the error is within the same source file)
 - **Void elements**: `<void>` acts as a transparent wrapper that never renders itself; useful for conditional rendering without extra DOM nodes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chocola",
-  "version": "2.0.0-next.6",
+  "version": "2.0.0-next.7",
   "description": "The sweetest way to build the web",
   "keywords": [
     "web",

--- a/parser/template.js
+++ b/parser/template.js
@@ -1,4 +1,3 @@
-import { throwError } from "../compiler/utils.js";
 import { compileExpression } from "./utils.js";
 import { hasDelIfAttr, getDelIfAttr, removeDelIfAttr } from "./context.js";
 
@@ -41,7 +40,7 @@ export function validateChainStructure(parent, sourceFile, sourceContent, parent
             if (lineNum !== null) loc = `${sourceFile}:${lineNum}`;
           }
         }
-        throwError(`${loc}\n    <${tag}> has ${attr} without a preceding if/del-if sibling`);
+        throw new Error(`${loc}\n    <${tag}> has ${attr} without a preceding if/del-if sibling`);
       }
       if (hasElse) {
         chainActive = false;

--- a/runtime/index.js
+++ b/runtime/index.js
@@ -1,0 +1,309 @@
+const exprCache = new Map();
+
+function compileExpression(expr, useCtx) {
+  const key = useCtx ? "ctx:" + expr : "raw:" + expr;
+  let fn = exprCache.get(key);
+  if (!fn) {
+    fn = useCtx
+      ? new Function("ctx", "with(ctx) { return (" + expr + "); }")
+      : new Function('"use strict"; return (' + expr + ")");
+    exprCache.set(key, fn);
+  }
+  return fn;
+}
+
+function interpolateNode(root, ctx) {
+  const stack = [root];
+  while (stack.length) {
+    const node = stack.pop();
+    if (node.nodeType === 3) {
+      const text = node.textContent
+        .replace(new RegExp(LBRACE_PH, "g"), "{")
+        .replace(new RegExp(RBRACE_PH, "g"), "}");
+      node.textContent = text.replace(/\{([^}]+)\}/g, (_, expr) => {
+        try {
+          return String(compileExpression(expr, true)(ctx));
+        } catch {
+          return "";
+        }
+      });
+    } else {
+      for (let i = node.childNodes.length - 1; i >= 0; i--) {
+        stack.push(node.childNodes[i]);
+      }
+    }
+  }
+}
+
+function applyConditionalToElement(child, ctx, chain, hasIf, hasDelIf, hasElif, hasElse) {
+  if (hasIf) {
+    const expr = child.getAttribute("if").slice(1, -1);
+    chain.active = true;
+    if (compileExpression(expr, true)(ctx)) {
+      chain.rendered = true;
+    } else {
+      child.style.display = "none";
+      chain.rendered = false;
+    }
+    child.removeAttribute("if");
+  } else if (hasDelIf) {
+    const expr = child.getAttribute("del:if").slice(1, -1);
+    chain.active = true;
+    if (compileExpression(expr, true)(ctx)) {
+      chain.rendered = true;
+    } else {
+      child.remove();
+      chain.rendered = false;
+    }
+    child.removeAttribute("del:if");
+  } else if (hasElif) {
+    const expr = child.getAttribute("elif").slice(1, -1);
+    if (compileExpression(expr, true)(ctx)) {
+      chain.rendered = true;
+    } else {
+      child.remove();
+    }
+    child.removeAttribute("elif");
+  } else if (hasElse) {
+    chain.rendered = true;
+    chain.active = false;
+    child.removeAttribute("else");
+  } else {
+    chain.active = false;
+    chain.rendered = false;
+  }
+}
+
+const LBRACE_PH = "_%%CHOCOLA-LBRACE%%_";
+const RBRACE_PH = "_%%CHOCOLA-RBRACE%%_";
+
+function interpolateAttributes(element, ctx) {
+  for (const el of [element, ...element.querySelectorAll("*")]) {
+    for (const attr of [...el.attributes]) {
+      const val = attr.value;
+      if (!val.includes("{") && !val.includes(LBRACE_PH)) continue;
+      const raw = val
+        .replace(new RegExp(LBRACE_PH, "g"), "{")
+        .replace(new RegExp(RBRACE_PH, "g"), "}");
+      attr.value = raw.replace(/\{([^}]+)\}/g, (_, expr) => {
+        try {
+          return String(compileExpression(expr, true)(ctx));
+        } catch {
+          return "";
+        }
+      });
+    }
+  }
+}
+
+function processConditionals(element, ctx, chain) {
+  for (const child of [...element.children]) {
+    const hasIf = child.hasAttribute("if");
+    const hasDelIf = child.hasAttribute("del:if");
+    const hasElif = child.hasAttribute("elif");
+    const hasElse = child.hasAttribute("else");
+
+    if ((hasElif || hasElse) && chain.rendered) {
+      child.remove();
+      if (hasElse) chain.active = false;
+      continue;
+    }
+
+    applyConditionalToElement(child, ctx, chain, hasIf, hasDelIf, hasElif, hasElse);
+
+    if (child.parentNode) {
+      processConditionals(child, ctx, chain);
+    }
+  }
+}
+
+function processSlots(element, projectedChildren) {
+  const slots = element.querySelectorAll("slot");
+  for (const slot of slots) {
+    const clone = projectedChildren.map(c => c.cloneNode(true));
+    slot.replaceWith(...clone);
+  }
+}
+
+let bindCounter = 0;
+
+function processBindAttributes(element) {
+  const bindings = [];
+  for (const attr of [...element.attributes]) {
+    if (attr.name.startsWith("bind:")) {
+      const prop = attr.name.slice(5);
+      const varName = attr.value;
+      const bindId = "b" + (bindCounter++);
+      element.setAttribute("data-chbind-" + bindId, "");
+      bindings.push({ prop, varName, bindId });
+      element.removeAttribute(attr.name);
+    }
+  }
+  return bindings;
+}
+
+function resolveDataBindings(element) {
+  const ids = [];
+  for (const attr of [...element.attributes]) {
+    const match = attr.name.match(/^data-chbind-(b\d+)$/);
+    if (match) {
+      ids.push(match[1]);
+      element.removeAttribute(attr.name);
+    }
+  }
+  return ids;
+}
+
+function collectBindings(root) {
+  const bindingDefs = [];
+  const idToEl = {};
+
+  for (const el of [root, ...root.querySelectorAll("*")]) {
+    bindingDefs.push(...processBindAttributes(el));
+    for (const id of resolveDataBindings(el)) {
+      idToEl[id] = el;
+    }
+  }
+  return { bindingDefs, idToEl };
+}
+
+class ChocolaComponent {
+  #template;
+  #hash;
+  #runtime;
+  #defaultProps;
+  #bakedComponent;
+  #ctx;
+  #eventListeners = [];
+  #children;
+  #childComponents;
+
+  constructor(config = {}) {
+    this.#template = config.template || "";
+    this.#hash = config.hash || "";
+    this.#runtime = config.runtime || null;
+    this.#defaultProps = config.props || {};
+    this.#childComponents = config.children || [];
+  }
+
+  #collectListeners(root, fn) {
+    const allEls = [root, ...root.querySelectorAll("*")];
+    const patches = [];
+
+    for (const el of allEls) {
+      const original = el.addEventListener;
+      el.addEventListener = (event, handler, options) => {
+        this.#eventListeners.push({ el, event, handler, options });
+        original.call(el, event, handler, options);
+      };
+      patches.push({ el, original });
+    }
+
+    try {
+      fn(root, this.#ctx);
+    } finally {
+      for (const { el, original } of patches) {
+        el.addEventListener = original;
+      }
+    }
+  }
+
+  #init(ctx) {
+    const mergedCtx = { ...this.#defaultProps, ...ctx };
+
+    const container = document.createElement("template");
+    container.innerHTML = this.#template;
+    const fragment = container.content;
+    const root = fragment.firstElementChild;
+
+    if (!root) {
+      console.error(`${this.#hash}: component template must have a single root element`);
+      return null;
+    }
+
+    processSlots(root, this.#children || []);
+    processConditionals(root, mergedCtx, { active: false, rendered: false });
+    interpolateAttributes(root, mergedCtx);
+    interpolateNode(root, mergedCtx);
+    root.classList.add(this.#hash);
+
+    const { bindingDefs, idToEl } = collectBindings(root);
+    this.#ctx = { ...mergedCtx };
+    for (const { prop, varName, bindId } of bindingDefs) {
+      const el = idToEl[bindId];
+      if (el) {
+        this.#ctx[varName] = prop === "self" ? el : el[prop];
+      }
+    }
+
+    if (this.#runtime) {
+      this.#collectListeners(root, (self, ctx) => {
+        this.#runtime(self, ctx);
+      });
+    }
+
+    this.#bakedComponent = root;
+    container.remove();
+    return root;
+  }
+
+  #childInstances = [];
+
+  #mountChildren(root) {
+    for (const { tag, compClass } of this.#childComponents) {
+      const els = root.querySelectorAll(tag);
+      for (const el of els) {
+        const props = {};
+        for (const attr of [...el.attributes]) {
+          if (attr.name.startsWith("data-ch") || attr.name === "if" || attr.name === "del:if" || attr.name === "elif" || attr.name === "else") continue;
+          props[attr.name] = attr.value;
+        }
+        const instance = new compClass();
+        instance.mount(el.parentNode, props);
+        this.#childInstances.push(instance);
+        el.remove();
+      }
+    }
+  }
+
+  mount(target, ctx = {}) {
+    if (target.nodeType !== 1) {
+      console.error(`${this.#hash}: mount target is not a valid DOM node`);
+      return;
+    }
+    this.#children = [...target.children];
+    this.#init(ctx);
+    if (this.#bakedComponent) {
+      target.appendChild(this.#bakedComponent);
+      this.#mountChildren(this.#bakedComponent);
+    }
+  }
+
+  remove() {
+    for (const { el, event, handler, options } of this.#eventListeners) {
+      el.removeEventListener(event, handler, options);
+    }
+    this.#eventListeners = [];
+    for (const child of this.#childInstances) {
+      child.remove();
+    }
+    this.#childInstances = [];
+    if (this.#bakedComponent) {
+      this.#bakedComponent.remove();
+      this.#bakedComponent = null;
+    }
+  }
+
+  update(ctx = {}) {
+    const mergedCtx = { ...this.#defaultProps, ...ctx };
+    const parent = this.#bakedComponent?.parentNode;
+    parent && this.remove();
+    this.#init(mergedCtx);
+    if (parent && this.#bakedComponent) {
+      parent.appendChild(this.#bakedComponent);
+      this.#mountChildren(this.#bakedComponent);
+    }
+  }
+}
+
+export { ChocolaComponent };


### PR DESCRIPTION
# feat: CSR for components [#47]
Introduces client-side rendering capabilities to the Chocola framework. Components can now be compiled into JavaScript classes that extend ChocolaComponent, enabling dynamic component rendering in the browser.

## Key changes:
- New runtime/index.js provides the ChocolaComponent base class with lifecycle methods (mount, update, remove)
- Component processor generates CSR class definitions from component templates
- Runtime generator creates separate files for CSR runtime, component classes, and event handlers
- Removed module type from runtime script tag to support inline execution
- Update docs [#64]